### PR TITLE
Update Nokia platform modules for Debian Bullseye compilation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,6 @@ include /usr/share/dpkg/pkg-info.mk
 
 export INSTALL_MOD_DIR:=extra
 
-PYTHON         ?= python2
 PYTHON3        ?= python3
 
 PACKAGE_PRE_NAME := sonic-platform-nokia
@@ -29,7 +28,7 @@ PLATFORM_DIR := sonic_platform
 CONF_DIR := conf
 
 %:
-	dh $@ --with systemd,python2,python3 --buildsystem=pybuild
+	dh $@ --with systemd,python3 --buildsystem=pybuild
 
 clean:
 	dh_testdir
@@ -44,7 +43,6 @@ build:
 	#make modules -C $(KERNEL_SRC)/build M=$(MODULE_SRC)
 	(for mod in $(MODULE_DIRS); do \
 		make modules -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules || exit 1; \
-		$(PYTHON) $${mod}/setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
 		$(PYTHON3) $${mod}/setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
 	done)
 
@@ -67,7 +65,6 @@ binary-indep:
 		cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTL_MOD_DIR); \
 		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system/; \
-		$(PYTHON) $${mod}/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
 		$(PYTHON3) $${mod}/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
 	done)
 	# Resuming debhelper scripts

--- a/debian/sonic-platform-nokia-chassis.install
+++ b/debian/sonic-platform-nokia-chassis.install
@@ -2,11 +2,6 @@ common/utils/nokia-watchdog.sh opt/srlinux/bin
 common/service/nokia-watchdog.service etc/systemd/system
 common/utils/openbdb.sh usr/local/bin
 common/service/openbdb.service etc/systemd/system
-chassis/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250_32x100g_4x400g-r0
-chassis/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250_cpm-r0
-chassis/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250-r0
-chassis/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250e_sup-r0
-chassis/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250e_36x400g-r0
 chassis/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250_32x100g_4x400g-r0
 chassis/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250_cpm-r0
 chassis/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7250-r0


### PR DESCRIPTION
Make sure kernel modules compile for 5.10 kernel, and remove Python 2
support.

This is part of upgrading SONiC to Debian Bullseye (Azure/sonic-buildimage#8191).

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>