### PR TITLE
Support show chassis module with correct linecard description

### DIFF
--- a/chassis/sonic_platform/module.py
+++ b/chassis/sonic_platform/module.py
@@ -61,7 +61,7 @@ class Module(ModuleBase):
         self.midplane = ""
         self.midplane_status = False
         self.reset()
-        self._update_module_hwsku_info()
+        self._update_module_hwsku_info_to_supervisor()
 
     def reset(self):
         self.asic_list = []
@@ -119,7 +119,7 @@ class Module(ModuleBase):
                 return eval(eeprom_info['eeprom_info'])
         return None
     
-    def _update_module_hwsku_info(self):
+    def _update_module_hwsku_info_to_supervisor(self):
         if self.get_type() != self.MODULE_TYPE_LINE or self._is_cpm:
             return
         else:
@@ -151,6 +151,7 @@ class Module(ModuleBase):
         Get module bulk info and cache it for 5 seconds to optimize the chassisd update which is in
         10 seconds intervak periodical query
         """
+        print("HHHH _get_module_bulk_info BEGIN {} type {}".format(self.description, self.get_type()))
         # No need to grpc call for supervisor card once it has been updated once
         if self.get_type() == self.MODULE_TYPE_SUPERVISOR:
             if self.oper_status == ModuleBase.MODULE_STATUS_ONLINE:
@@ -190,6 +191,7 @@ class Module(ModuleBase):
                 if self.get_type() != self.MODULE_TYPE_LINE:
                     self.description = module_info.name
                     if module_info.name in DESCRIPTION_MAPPING:
+                        print("HHHH module_info.name in DESCRIPTION_MAPPING {}".format(DESCRIPTION_MAPPING[module_info.name]))
                         self.description = DESCRIPTION_MAPPING[module_info.name]
                         if platform_module_type == platform_ndk_pb2.HwModuleType.HW_MODULE_TYPE_CONTROL:
                             if self.chassis_type == platform_ndk_pb2.HwChassisType.HW_CHASSIS_TYPE_IXR6:

--- a/chassis/sonic_platform/module.py
+++ b/chassis/sonic_platform/module.py
@@ -134,7 +134,6 @@ class Module(ModuleBase):
         return None
     
     def _get_lc_module_description(self):
-
         chassis_state_db = daemon_base.db_connect("CHASSIS_STATE_DB")
         nokia_hwsku_tbl = swsscommon.Table(chassis_state_db, NOKIA_MODULE_HWSKU_INFO_TABLE)
         status, fvs = nokia_hwsku_tbl.get(self.module_name)

--- a/chassis/sonic_platform/module.py
+++ b/chassis/sonic_platform/module.py
@@ -151,7 +151,6 @@ class Module(ModuleBase):
         Get module bulk info and cache it for 5 seconds to optimize the chassisd update which is in
         10 seconds intervak periodical query
         """
-        print("HHHH _get_module_bulk_info BEGIN {} type {}".format(self.description, self.get_type()))
         # No need to grpc call for supervisor card once it has been updated once
         if self.get_type() == self.MODULE_TYPE_SUPERVISOR:
             if self.oper_status == ModuleBase.MODULE_STATUS_ONLINE:
@@ -191,7 +190,6 @@ class Module(ModuleBase):
                 if self.get_type() != self.MODULE_TYPE_LINE:
                     self.description = module_info.name
                     if module_info.name in DESCRIPTION_MAPPING:
-                        print("HHHH module_info.name in DESCRIPTION_MAPPING {}".format(DESCRIPTION_MAPPING[module_info.name]))
                         self.description = DESCRIPTION_MAPPING[module_info.name]
                         if platform_module_type == platform_ndk_pb2.HwModuleType.HW_MODULE_TYPE_CONTROL:
                             if self.chassis_type == platform_ndk_pb2.HwChassisType.HW_CHASSIS_TYPE_IXR6:


### PR DESCRIPTION
This PR is to resolve the issue https://github.com/Nokia-ION/ndk/issues/45. "show chassis modules status " shows linecard at 36x400G , even though the Linecard Hwsku is 36x100G

It's required to get the real hwsku with the show command. 

Solution is to have linecard update its hwsku information to CHASSIS_STATE_DB table NOKIA_MODULE_HWSKU_INFO_TABLE. Thus correct information will be in STATE_DB table CHASSIS_MODULE_INFO_TABLE. Show chassis module status will have correct information with the fix. 

Test:
Tested on hardware with 100G linecards. "Show chassis module status" shows correct description with the fix now. Tested on CPM  and linecard for the show output. 