### PR TITLE
[H4-64D]Add support for H4-64D platform.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,11 @@ Architecture: amd64
 Depends:  ${misc:Depends}
 Description: kernel modules for platform devices such as fan, led, sfp
 
+Package: sonic-platform-nokia-ixr7220h4-64d
+Architecture: amd64
+Depends:  ${misc:Depends}
+Description: kernel modules for platform devices such as sfp, fan, psu, led
+
 Package: sonic-platform-nokia-ixr7220h5-64d
 Architecture: amd64
 Depends:  ${misc:Depends}

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ KERNEL_SRC :=  /lib/modules/$(KVERSION)
 
 
 MOD_SRC_DIR:= $(shell pwd)
-MODULE_DIRS:= chassis ixr7220h3 ixr7220h4-32d ixr7220h5-64d
+MODULE_DIRS:= chassis ixr7220h3 ixr7220h4-32d ixr7220h5-64d ixr7220h4-64d
 MODULE_DIR := modules
 UTILS_DIR := utils
 SERVICE_DIR := service

--- a/debian/sonic-platform-nokia-ixr7220h4-64d.install
+++ b/debian/sonic-platform-nokia-ixr7220h4-64d.install
@@ -1,0 +1,3 @@
+ixr7220h4-64d/scripts/h4_64d_platform_init.sh usr/local/bin
+ixr7220h4-64d/service/h4_64d_platform_init.service etc/systemd/system
+ixr7220h4-64d/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7220_h4-r0

--- a/debian/sonic-platform-nokia-ixr7220h4-64d.postinst
+++ b/debian/sonic-platform-nokia-ixr7220h4-64d.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+# postinst script for sonic-platform-nokia-IXR7220-H4-64D
+#
+# see: dh_installdeb(1)
+
+chmod a+x /usr/local/bin/h4_64d_platform_init.sh
+systemctl enable h4_64d_platform_init.service
+systemctl start h4_64d_platform_init.service

--- a/ixr7220h4-64d/modules/Makefile
+++ b/ixr7220h4-64d/modules/Makefile
@@ -1,0 +1,1 @@
+obj-m := sys_fpga.o smb_cpld.o fan_cpld.o scm_cpld.o pdbl_cpld.o pdbr_cpld.o dni_psu.o

--- a/ixr7220h4-64d/modules/dni_psu.c
+++ b/ixr7220h4-64d/modules/dni_psu.c
@@ -1,0 +1,559 @@
+/*
+ * An hwmon driver for delta PSU
+  *
+ * Copyright (C) 2016 Delta Network Technology Corporation
+ * Copyright (C) 2024 Nokia Corporation.
+ * 
+ * DNI <DNIsales@delta.com.tw>
+ *
+ * Based on ym2651y.c
+ * Based on ad7414.c
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/slab.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+
+#define MAX_FAN_DUTY_CYCLE 100
+#define SWPLD_REG 0x31
+#define SWPLD_PSU_MUX_REG 0x21
+#define SELECT_PSU1_EEPROM 0x00
+#define SELECT_PSU2_EEPROM 0x20
+
+u8 psu_member_data = 0x00;
+
+
+/* Address scanned */
+static const unsigned short normal_i2c[] = { 0x58, 0x59, I2C_CLIENT_END };
+
+/* This is additional data */
+struct dni_psu_data {
+	struct device	*hwmon_dev;
+	struct mutex	update_lock;
+	char		valid;		
+	unsigned long	last_updated;	/* In jiffies */
+
+	/* Registers value */
+	u8	vout_mode;
+	u16	in1_input;
+	u16	in2_input;
+	u16	curr1_input;
+	u16	curr2_input;
+	u16	power1_input;
+	u16	power2_input;
+	u16	temp_input[2];
+	u8	fan_target;
+	u16	fan_duty_cycle_input[2];
+	u16	fan_speed_input[2];
+	u8	mfr_model[16];
+	u8	mfr_serial[16];
+};
+
+static int two_complement_to_int(u16 data, u8 valid_bit, int mask);
+static ssize_t set_fan_duty_cycle_input(struct device *dev, struct device_attribute \
+                                *dev_attr, const char *buf, size_t count);
+static ssize_t for_linear_data(struct device *dev, struct device_attribute \
+                                                        *dev_attr, char *buf);
+static ssize_t for_fan_target(struct device *dev, struct device_attribute \
+                                                        *dev_attr, char *buf);
+static ssize_t for_vout_data(struct device *dev, struct device_attribute \
+                                                        *dev_attr, char *buf);
+static int dni_psu_read_byte(struct i2c_client *client, u8 reg);
+static int dni_psu_read_word(struct i2c_client *client, u8 reg);
+static int dni_psu_write_word(struct i2c_client *client, u8 reg, \
+								u16 value);
+static int dni_psu_read_block(struct i2c_client *client, u8 command, \
+                                                       u8 *data, int data_len);
+static struct dni_psu_data *dni_psu_update_device( \
+                                                        struct device *dev);
+static ssize_t for_ascii(struct device *dev, struct device_attribute \
+                                                        *dev_attr, char *buf);
+static ssize_t set_w_member_data(struct device *dev, struct device_attribute \
+				*dev_att, const char *buf, size_t count);
+static ssize_t for_r_member_data(struct device *dev, struct device_attribute \
+	 						*dev_attr, char *buf);
+
+enum dni_psu_sysfs_attributes {
+	PSU_V_IN,
+	PSU_V_OUT,
+	PSU_I_IN,
+	PSU_I_OUT,
+	PSU_P_IN,
+	PSU_P_OUT,
+	PSU_TEMP1_INPUT,
+	PSU_FAN1_FAULT,
+	PSU_FAN1_DUTY_CYCLE,
+	PSU_FAN1_SPEED,
+	PSU_MFR_MODEL,
+	PSU_MFR_SERIAL,
+	PSU_SELECT_MEMBER,
+};
+
+static ssize_t set_w_member_data(struct device *dev, struct device_attribute \
+				*dev_attr, const char *buf, size_t count)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(dev_attr);
+	long data;
+	int error;
+	if (attr->index == PSU_SELECT_MEMBER) {
+		error = kstrtol(buf, 16, &data);
+		if (error)
+			return error;
+		if (SELECT_PSU1_EEPROM == data) {
+			psu_member_data = SELECT_PSU1_EEPROM;
+		} else if (SELECT_PSU2_EEPROM == data) {
+			psu_member_data = SELECT_PSU2_EEPROM;
+		} else {
+			return -EINVAL;
+		}
+	}
+	return count;
+}
+
+static ssize_t for_r_member_data(struct device *dev, struct device_attribute \
+	 						*dev_attr, char *buf)
+{
+	return sprintf(buf, "0x%02X\n", psu_member_data);
+}
+
+static int two_complement_to_int(u16 data, u8 valid_bit, int mask)
+{
+	u16  valid_data  = data & mask;
+    	bool is_negative = valid_data >> (valid_bit - 1);
+
+    	return is_negative ? (-(((~valid_data) & mask) + 1)) : valid_data;
+}
+
+static ssize_t set_fan_duty_cycle_input(struct device *dev, struct device_attribute \
+				*dev_attr, const char *buf, size_t count)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(dev_attr);
+	struct i2c_client *client = to_i2c_client(dev);
+	struct dni_psu_data *data = i2c_get_clientdata(client);
+	int nr = (attr->index == PSU_FAN1_DUTY_CYCLE) ? 0 : 1;
+	long speed;
+	int error;
+	
+	error = kstrtol(buf, 10, &speed);
+	if (error)
+		return error;
+
+	if (speed < 0 || speed > MAX_FAN_DUTY_CYCLE)
+		return -EINVAL;
+
+	/* Select SWPLD PSU offset */
+
+	mutex_lock(&data->update_lock);
+	data->fan_duty_cycle_input[nr] = speed;
+	dni_psu_write_word(client, 0x3B + nr, data->fan_duty_cycle_input[nr]);
+	mutex_unlock(&data->update_lock);
+
+	return count;
+}
+
+static ssize_t for_linear_data(struct device *dev, struct device_attribute \
+							*dev_attr, char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(dev_attr);
+	struct dni_psu_data *data = dni_psu_update_device(dev);
+
+	u16 value = 0;
+	int exponent, mantissa;
+	int multiplier = 1000;
+	
+	switch (attr->index) {
+	case PSU_V_IN:
+		value = data->in1_input;
+		break;
+	case PSU_I_IN:
+		value = data->curr1_input;
+                break;
+	case PSU_I_OUT:
+		value = data->curr2_input;
+                break;
+	case PSU_P_IN:
+		value = data->power1_input;
+                multiplier = 1000*1000;		
+                break;
+	case PSU_P_OUT:
+		value = data->power2_input;
+                multiplier = 1000*1000;		
+                break;
+	case PSU_TEMP1_INPUT:
+		value = data->temp_input[0];
+		break;
+	case PSU_FAN1_DUTY_CYCLE:
+		multiplier = 1;
+		value = data->fan_duty_cycle_input[0];
+		break;
+	case PSU_FAN1_SPEED:
+		multiplier = 1;
+		value = data->fan_speed_input[0];
+		break;
+	default:
+		break;
+	}
+
+	exponent = two_complement_to_int(value >> 11, 5, 0x1f);
+	mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);
+
+	return (exponent >= 0) ? sprintf(buf, "%d\n",	\
+		(mantissa << exponent) * multiplier) :	\
+	    sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));	
+}
+
+static ssize_t for_fan_target(struct device *dev, struct device_attribute \
+							*dev_attr, char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(dev_attr);
+    	struct dni_psu_data *data = dni_psu_update_device(dev);
+
+    	u8 shift = (attr->index == PSU_FAN1_FAULT) ? 7 : 6;
+
+    	return sprintf(buf, "%d\n", data->fan_target >> shift);
+}
+
+static ssize_t for_vout_data(struct device *dev, struct device_attribute \
+		 					*dev_attr, char *buf)
+{
+	struct dni_psu_data *data = dni_psu_update_device(dev);
+	int exponent, mantissa;
+	int multiplier = 1000;
+		
+	exponent = two_complement_to_int(data->vout_mode, 5, 0x1f);
+	mantissa = data->in2_input;
+	
+	return (exponent > 0) ? sprintf(buf, "%d\n", \
+                (mantissa * multiplier) / (1 << exponent)): \
+        sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));
+}
+
+static ssize_t for_ascii(struct device *dev, struct device_attribute \
+	 						*dev_attr, char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(dev_attr);
+	struct dni_psu_data *data = dni_psu_update_device(dev);
+	u8 *ptr = NULL;
+
+	if (!data->valid)
+		return 0;
+
+	switch (attr->index) {
+	case PSU_MFR_MODEL:
+		ptr = data->mfr_model + 1;
+		break;
+	case PSU_MFR_SERIAL:
+		ptr = data->mfr_serial + 1;
+		break;
+	default:
+		return 0;
+	}
+	return sprintf(buf, "%s\n", ptr);
+}
+static int dni_psu_read_byte(struct i2c_client *client, u8 reg)
+{
+	return i2c_smbus_read_byte_data(client, reg);
+}
+
+static int dni_psu_read_word(struct i2c_client *client, u8 reg)
+{
+	return i2c_smbus_read_word_data(client, reg);
+}
+
+static int dni_psu_write_word(struct i2c_client *client, u8 reg, \
+								u16 value)
+{
+	union i2c_smbus_data data;
+        data.word = value;
+        return i2c_smbus_xfer(client->adapter, client->addr, 
+				client->flags |= I2C_CLIENT_PEC,
+                              	I2C_SMBUS_WRITE, reg,
+                              	I2C_SMBUS_WORD_DATA, &data);
+
+}
+
+static int dni_psu_read_block(struct i2c_client *client, u8 command, \
+							u8 *data, int data_len)
+{
+	int result = i2c_smbus_read_i2c_block_data(client, command, data_len,
+									data);
+	if (unlikely(result < 0))
+		goto abort;
+	if (unlikely(result != data_len)) {
+		result = -EIO;
+		goto abort;
+	}
+
+	result = 0;
+abort:
+	return result;
+
+}
+
+struct reg_data_byte {
+	u8 reg;
+	u8 *value;
+};
+
+struct reg_data_word {
+	u8 reg;
+	u16 *value;
+};
+
+static struct dni_psu_data *dni_psu_update_device( \
+							struct device *dev)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct dni_psu_data *data = i2c_get_clientdata(client);
+	
+	mutex_lock(&data->update_lock);
+
+	/* Select SWPLD PSU offset */
+
+	if (time_after(jiffies, data->last_updated)) {
+		int i, status;
+		u8 command;
+		struct reg_data_byte regs_byte[] = {
+				{0x20, &data->vout_mode},
+				{0x81, &data->fan_target}
+		};
+		struct reg_data_word regs_word[] = {
+				{0x88, &data->in1_input},
+				{0x8b, &data->in2_input},
+				{0x89, &data->curr1_input},
+				{0x8c, &data->curr2_input},
+				{0x96, &data->power2_input},
+				{0x97, &data->power1_input},
+				{0x8d, &(data->temp_input[0])},
+				{0x8e, &(data->temp_input[1])},
+				{0x3b, &(data->fan_duty_cycle_input[0])},
+				{0x90, &(data->fan_speed_input[0])},
+		};
+
+		dev_dbg(&client->dev, "start data update\n");
+
+		/* one milliseconds from now */
+		data->last_updated = jiffies + HZ / 1000;
+		
+		for (i = 0; i < ARRAY_SIZE(regs_byte); i++) {
+			status = dni_psu_read_byte(client, 
+							regs_byte[i].reg);
+			if (status < 0) {
+				dev_dbg(&client->dev, "reg %d, err %d\n",
+					regs_byte[i].reg, status);
+				*(regs_byte[i].value) = 0;
+			} else {
+				*(regs_byte[i].value) = status;
+			}
+		}
+
+		for (i = 0; i < ARRAY_SIZE(regs_word); i++) {
+			status = dni_psu_read_word(client,
+							regs_word[i].reg);
+			if (status < 0) {
+				dev_dbg(&client->dev, "reg %d, err %d\n",
+					regs_word[i].reg, status);
+				*(regs_word[i].value) = 0;
+			} else {
+				*(regs_word[i].value) = status;
+			}
+		}
+
+		command = 0x9a;		/* PSU mfr_model */
+		//data->mfr_model[1] = '\0';
+		status = dni_psu_read_block(client, command, 
+		data->mfr_model, ARRAY_SIZE(data->mfr_model) - 1);
+    	data->mfr_model[ARRAY_SIZE(data->mfr_model) - 1] = '\0';
+    	if (status < 0) {
+        	dev_dbg(&client->dev, "reg %d, err %d\n", command,status);
+        	data->mfr_model[1] = '\0';
+    	}
+
+    	command = 0x9e;		/* PSU mfr_serial */
+    	//data->mfr_serial[1] = '\0';
+    	status = dni_psu_read_block(client, command, 
+		data->mfr_serial, ARRAY_SIZE(data->mfr_serial) - 1);
+    	data->mfr_serial[ARRAY_SIZE(data->mfr_serial) - 1] = '\0';
+    	if (status < 0) {
+            dev_dbg(&client->dev, "reg %d, err %d\n", command,status);
+            data->mfr_serial[1] = '\0';
+   		}	
+		
+		data->valid = 1;
+	}
+	
+	mutex_unlock(&data->update_lock);
+	
+	return data;
+
+}
+
+/* sysfs attributes for hwmon */
+static SENSOR_DEVICE_ATTR(in1_input, S_IRUGO, for_linear_data, NULL, PSU_V_IN);
+static SENSOR_DEVICE_ATTR(in2_input, S_IRUGO, for_vout_data,   NULL, PSU_V_OUT);
+static SENSOR_DEVICE_ATTR(curr1_input, S_IRUGO, for_linear_data, NULL, PSU_I_IN);
+static SENSOR_DEVICE_ATTR(curr2_input, S_IRUGO, for_linear_data, NULL, PSU_I_OUT);
+static SENSOR_DEVICE_ATTR(power1_input, S_IRUGO, for_linear_data, NULL, PSU_P_IN);
+static SENSOR_DEVICE_ATTR(power2_input, S_IRUGO, for_linear_data, NULL, PSU_P_OUT);
+static SENSOR_DEVICE_ATTR(temp1_input,	\
+		S_IRUGO, for_linear_data,	NULL, PSU_TEMP1_INPUT);
+static SENSOR_DEVICE_ATTR(fan1_target,	\
+		S_IRUGO, for_fan_target, 	NULL, PSU_FAN1_FAULT);
+static SENSOR_DEVICE_ATTR(fan1_set_percentage, S_IWUSR | S_IRUGO, \
+		for_linear_data, set_fan_duty_cycle_input, PSU_FAN1_DUTY_CYCLE);
+static SENSOR_DEVICE_ATTR(fan1_input, 	\
+		S_IRUGO, for_linear_data,	NULL, PSU_FAN1_SPEED);
+static SENSOR_DEVICE_ATTR(psu_mfr_model, 	\
+		S_IRUGO, for_ascii, NULL, PSU_MFR_MODEL);
+static SENSOR_DEVICE_ATTR(psu_mfr_serial,	\
+		S_IRUGO, for_ascii, NULL, PSU_MFR_SERIAL);
+static SENSOR_DEVICE_ATTR(psu_select_member, S_IWUSR | S_IRUGO, \
+		for_r_member_data, set_w_member_data, PSU_SELECT_MEMBER);
+
+static struct attribute *dni_psu_attributes[] = {
+	&sensor_dev_attr_in1_input.dev_attr.attr,
+	&sensor_dev_attr_in2_input.dev_attr.attr,
+	&sensor_dev_attr_curr1_input.dev_attr.attr,
+	&sensor_dev_attr_curr2_input.dev_attr.attr,
+	&sensor_dev_attr_power1_input.dev_attr.attr,
+	&sensor_dev_attr_power2_input.dev_attr.attr,
+	&sensor_dev_attr_temp1_input.dev_attr.attr,
+	&sensor_dev_attr_fan1_target.dev_attr.attr,
+	&sensor_dev_attr_fan1_set_percentage.dev_attr.attr,
+	&sensor_dev_attr_fan1_input.dev_attr.attr,
+	&sensor_dev_attr_psu_mfr_model.dev_attr.attr,
+	&sensor_dev_attr_psu_mfr_serial.dev_attr.attr,
+	&sensor_dev_attr_psu_select_member.dev_attr.attr,
+	NULL
+};
+
+static const struct attribute_group dni_psu_group = {
+	.attrs = dni_psu_attributes,
+};
+
+static int dni_psu_probe(struct i2c_client *client,
+				const struct i2c_device_id *id)
+{
+	struct dni_psu_data *data;
+	int status;
+
+	if (!i2c_check_functionality(client->adapter, 
+		I2C_FUNC_SMBUS_BYTE_DATA | I2C_FUNC_SMBUS_WORD_DATA)) {
+		status = -EIO;
+		goto exit;
+	}
+	
+	data = kzalloc(sizeof(*data), GFP_KERNEL);
+	if (!data) {
+		status = -ENOMEM;
+		goto exit;
+	}
+
+	i2c_set_clientdata(client, data);
+	data->valid = 0;
+	mutex_init(&data->update_lock);
+	
+	dev_info(&client->dev, "new chip found\n");
+
+	/* Register sysfs hooks */
+	status = sysfs_create_group(&client->dev.kobj, &dni_psu_group);
+	if (status) 
+		goto exit_sysfs_create_group;
+
+	data->hwmon_dev = hwmon_device_register(&client->dev);
+	if (IS_ERR(data->hwmon_dev)) {
+		status = PTR_ERR(data->hwmon_dev);
+		goto exit_hwmon_device_register;
+	}
+
+	return 0;
+	
+exit_hwmon_device_register:
+	sysfs_remove_group(&client->dev.kobj, &dni_psu_group);
+exit_sysfs_create_group:
+	kfree(data);
+exit:
+	return status;
+}
+
+static void dni_psu_remove(struct i2c_client *client)
+{
+	struct dni_psu_data *data = i2c_get_clientdata(client);
+	hwmon_device_unregister(data->hwmon_dev);
+	sysfs_remove_group(&client->dev.kobj, &dni_psu_group);
+	kfree(data);
+}
+
+enum id_name {
+	dni_psu,
+	dps_2400ab_1
+};
+
+static const struct of_device_id dni_psu_ids[] = {
+    {
+        .compatible = "dni,dps_2400ab",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, dni_psu_ids);
+
+static const struct i2c_device_id dni_psu_id[] = {
+	{ "dni_psu", dni_psu },
+	{ "dps_2400ab_1", dps_2400ab_1 },
+	{}
+};
+MODULE_DEVICE_TABLE(i2c, dni_psu_id);
+
+/* This is the driver that will be inserted */
+static struct i2c_driver dni_psu_driver = {
+        .class          = I2C_CLASS_HWMON,
+        .driver = {
+                .name   = "dps_2400ab_1",
+				.of_match_table = of_match_ptr(dni_psu_ids),
+        },
+        .probe          = dni_psu_probe,
+        .remove         = dni_psu_remove,
+        .id_table       = dni_psu_id,
+        .address_list   = normal_i2c,
+};
+
+static int __init dni_psu_init(void)
+{
+	return i2c_add_driver(&dni_psu_driver);
+}
+
+static void __exit dni_psu_exit(void)
+{
+	i2c_del_driver(&dni_psu_driver);
+}
+
+
+MODULE_DESCRIPTION("DPS_PSU Driver");
+MODULE_LICENSE("GPL");
+
+module_init(dni_psu_init);
+module_exit(dni_psu_exit);

--- a/ixr7220h4-64d/modules/fan_cpld.c
+++ b/ixr7220h4-64d/modules/fan_cpld.c
@@ -1,0 +1,534 @@
+//  * FAN CPLD
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  * 
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "fan_cpld"
+
+// REGISTERS ADDRESS MAP
+#define MINOR_REV_REG               0x00
+#define MAJOR_REV_REG               0x01
+#define PCB_VERSION_REG             0x02
+#define SCRATCH_REG                 0x04
+#define TEMP_SENSOR_REG             0x08
+#define LED_STATUS_REG              0x09
+#define FAN_PRESENCE_REG            0x10
+#define EEPROM_PROTECT_REG          0x18
+#define FAN_ENABLE_REG              0x1A
+#define FAN_ENABLE_PROTECT_REG      0x1B
+#define WATCHDOG_ENABLE_REG         0x20
+#define WATCHDOG_TIMER_REG          0x21
+#define FAN1_PWM_REG                0x30
+#define FAN3_PWM_REG                0x31
+#define FAN5_PWM_REG                0x32
+#define FAN7_PWM_REG                0x33
+#define FAN1_SPEED_REG              0x40
+#define FAN2_SPEED_REG              0x50
+#define FAN3_SPEED_REG              0x41
+#define FAN4_SPEED_REG              0x51
+#define FAN5_SPEED_REG              0x42
+#define FAN6_SPEED_REG              0x52
+#define FAN7_SPEED_REG              0x43
+#define FAN8_SPEED_REG              0x53
+#define FAN_HITLESS_REG             0x60
+#define FAN_MISC_REG                0x61
+
+// REG BIT FIELD POSITION or MASK
+#define BOARD_INFO_REG_TYPE_MSK     0xF
+
+#define FAN1_LED_REG                0x0
+#define FAN2_LED_REG                0x2
+#define FAN3_LED_REG                0x4
+#define FAN4_LED_REG                0x6
+
+#define FAN1_PRESENCE_REG           0x0
+#define FAN2_PRESENCE_REG           0x1
+#define FAN3_PRESENCE_REG           0x2
+#define FAN4_PRESENCE_REG           0x3
+
+#define FAN1_POWER_REG              0x0
+#define FAN2_POWER_REG              0x1
+#define FAN3_POWER_REG              0x2
+#define FAN4_POWER_REG              0x3
+
+#define FAN1_REG                    0x0
+#define FAN2_REG                    0x1
+#define FAN3_REG                    0x2
+#define FAN4_REG                    0x3
+#define FAN5_REG                    0x4
+#define FAN6_REG                    0x5
+#define FAN7_REG                    0x6
+#define FAN8_REG                    0x7
+
+static const unsigned short cpld_address_list[] = {0x33, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int code_major_ver;
+    int code_minor_ver;
+    int board_ver;
+};
+
+enum fan_led_mode {
+    FAN_LED_OFF,
+    FAN_LED_GREEN,
+    FAN_LED_RED,
+    FAN_LED_BASE
+};
+char *fan_led_mode_str[]={"off", "green", "red", "base"};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+static ssize_t show_code_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%d.%d\n", data->code_major_ver, data->code_minor_ver);
+}
+
+static ssize_t show_board_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    char *str_ver = NULL;
+    
+    switch (data->board_ver) {
+    case 0:
+        str_ver = "R0A";
+        break; 
+    case 1:
+        str_ver = "R0B";
+        break; 
+    case 2:
+        str_ver = "R0C";
+        break; 
+    case 4:
+        str_ver = "R0D";
+        break;
+    case 5:
+        str_ver = "R01";
+        break;     
+    default:
+        str_ver = "Unknown";
+        break;
+    }
+
+    return sprintf(buf, "0x%x %s\n", data->board_ver, str_ver);
+}
+
+static ssize_t show_scratch(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+      
+    val = cpld_i2c_read(data, SCRATCH_REG);
+
+    return sprintf(buf, "%02x\n", val);
+}
+
+static ssize_t set_scratch(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 0xFF) {
+        return -EINVAL;
+    }
+
+    cpld_i2c_write(data, SCRATCH_REG, usr_val);
+
+    return count;
+}
+
+static ssize_t show_fan_led_status(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, LED_STATUS_REG);
+    val = (val >> sda->index) & 0x3;
+
+    return sprintf(buf,"%s\n",fan_led_mode_str[val]);
+}
+
+static ssize_t set_fan_led_status(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, mask=0, usr_val=0;
+    int i;
+
+    mask = (~(0x3 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, LED_STATUS_REG);
+    reg_val = reg_val & mask;
+
+    for(i=FAN_LED_OFF; i<FAN_LED_BASE; i++) {
+        if(strncmp(buf, fan_led_mode_str[i],strlen(fan_led_mode_str[i]))==0) {
+            usr_val = i << sda->index;
+            cpld_i2c_write(data, LED_STATUS_REG, reg_val|usr_val);
+            break;
+        }
+    }
+
+    return count;
+}
+
+static ssize_t show_fan_present(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, FAN_PRESENCE_REG);
+    
+    /* If the bit is set, fan is not present. So, we are toggling intentionally */
+    return sprintf(buf,"%d\n",(val>>sda->index) & 0x1 ? 0:1);
+}
+
+static ssize_t show_fan_power_status(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, FAN_ENABLE_REG);
+    
+    /* If the bit is set, fan is disabled */
+    return sprintf(buf,"%d\n",(val>>sda->index) & 0x1 ? 0:1);
+}
+
+static ssize_t set_fan_power_status(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, FAN_ENABLE_REG);
+    reg_val = reg_val & mask;
+
+    usr_val = (!usr_val) << sda->index;
+
+    cpld_i2c_write(data, FAN_ENABLE_REG, (reg_val|usr_val));
+
+    return count;
+
+}
+
+static ssize_t show_fan_pwm(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    u8 pwm_reg = 0;
+    switch (sda->index) {
+    case 0: case 1:
+        pwm_reg = FAN1_PWM_REG;
+        break; 
+    case 2: case 3:
+        pwm_reg = FAN3_PWM_REG;
+        break; 
+    case 4: case 5:
+        pwm_reg = FAN5_PWM_REG;
+        break; 
+    case 6: case 7:
+        pwm_reg = FAN7_PWM_REG;
+        break;
+    }
+
+    val = cpld_i2c_read(data, pwm_reg);
+
+    return sprintf(buf, "%d\n", val);
+}
+
+static ssize_t set_fan_pwm(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 usr_val = 0;
+    u8 pwm_reg = 0;
+
+    int ret = kstrtou8(buf, 0, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 0xFF) {
+        return -EINVAL;
+    }
+ 
+    switch (sda->index) {
+    case 0: case 1:
+        pwm_reg = FAN1_PWM_REG;
+        break; 
+    case 2: case 3:
+        pwm_reg = FAN3_PWM_REG;
+        break; 
+    case 4: case 5:
+        pwm_reg = FAN5_PWM_REG;
+        break; 
+    case 6: case 7:
+        pwm_reg = FAN7_PWM_REG;
+        break;
+    }
+
+    cpld_i2c_write(data, pwm_reg, usr_val);
+
+    return count;
+}
+
+static ssize_t show_fan_speed(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    u8 speed_reg = 0; 
+    int val_rpm = 0;
+    switch (sda->index) {
+    case 0:
+        speed_reg = FAN1_SPEED_REG;
+        break; 
+    case 1:
+        speed_reg = FAN2_SPEED_REG;
+        break;
+    case 2:
+        speed_reg = FAN3_SPEED_REG;
+        break;
+    case 3:
+        speed_reg = FAN4_SPEED_REG;
+        break;
+    case 4:
+        speed_reg = FAN5_SPEED_REG;
+        break;
+    case 5:
+        speed_reg = FAN6_SPEED_REG;
+        break;
+    case 6:
+        speed_reg = FAN7_SPEED_REG;
+        break;
+    case 7:
+        speed_reg = FAN8_SPEED_REG;
+        break;
+
+    }
+
+    val = cpld_i2c_read(data, speed_reg);
+    val_rpm = (val*60000)/1048; 
+
+    return sprintf(buf, "%d\n", val_rpm);
+}
+
+// sysfs attributes 
+static SENSOR_DEVICE_ATTR(code_ver, S_IRUGO, show_code_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(board_ver, S_IRUGO, show_board_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(scratch, S_IRUGO | S_IWUSR, show_scratch, set_scratch, 0);
+static SENSOR_DEVICE_ATTR(fan1_led, S_IRUGO | S_IWUSR, show_fan_led_status, set_fan_led_status, FAN1_LED_REG);
+static SENSOR_DEVICE_ATTR(fan2_led, S_IRUGO | S_IWUSR, show_fan_led_status, set_fan_led_status, FAN2_LED_REG);
+static SENSOR_DEVICE_ATTR(fan3_led, S_IRUGO | S_IWUSR, show_fan_led_status, set_fan_led_status, FAN3_LED_REG);
+static SENSOR_DEVICE_ATTR(fan4_led, S_IRUGO | S_IWUSR, show_fan_led_status, set_fan_led_status, FAN4_LED_REG);
+static SENSOR_DEVICE_ATTR(fan1_present, S_IRUGO, show_fan_present, NULL, FAN1_PRESENCE_REG);
+static SENSOR_DEVICE_ATTR(fan2_present, S_IRUGO, show_fan_present, NULL, FAN2_PRESENCE_REG);
+static SENSOR_DEVICE_ATTR(fan3_present, S_IRUGO, show_fan_present, NULL, FAN3_PRESENCE_REG);
+static SENSOR_DEVICE_ATTR(fan4_present, S_IRUGO, show_fan_present, NULL, FAN4_PRESENCE_REG);
+static SENSOR_DEVICE_ATTR(fan1_power, S_IRUGO | S_IWUSR, show_fan_power_status, set_fan_power_status, FAN1_POWER_REG);
+static SENSOR_DEVICE_ATTR(fan2_power, S_IRUGO | S_IWUSR, show_fan_power_status, set_fan_power_status, FAN2_POWER_REG);
+static SENSOR_DEVICE_ATTR(fan3_power, S_IRUGO | S_IWUSR, show_fan_power_status, set_fan_power_status, FAN3_POWER_REG);
+static SENSOR_DEVICE_ATTR(fan4_power, S_IRUGO | S_IWUSR, show_fan_power_status, set_fan_power_status, FAN4_POWER_REG);
+static SENSOR_DEVICE_ATTR(pwm1, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN1_REG);
+static SENSOR_DEVICE_ATTR(pwm2, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN2_REG);
+static SENSOR_DEVICE_ATTR(pwm3, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN3_REG);
+static SENSOR_DEVICE_ATTR(pwm4, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN4_REG);
+static SENSOR_DEVICE_ATTR(pwm5, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN5_REG);
+static SENSOR_DEVICE_ATTR(pwm6, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN6_REG);
+static SENSOR_DEVICE_ATTR(pwm7, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN7_REG);
+static SENSOR_DEVICE_ATTR(pwm8, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, FAN8_REG);
+static SENSOR_DEVICE_ATTR(fan1_speed, S_IRUGO, show_fan_speed, NULL, FAN1_REG);
+static SENSOR_DEVICE_ATTR(fan2_speed, S_IRUGO, show_fan_speed, NULL, FAN2_REG);
+static SENSOR_DEVICE_ATTR(fan3_speed, S_IRUGO, show_fan_speed, NULL, FAN3_REG);
+static SENSOR_DEVICE_ATTR(fan4_speed, S_IRUGO, show_fan_speed, NULL, FAN4_REG);
+static SENSOR_DEVICE_ATTR(fan5_speed, S_IRUGO, show_fan_speed, NULL, FAN5_REG);
+static SENSOR_DEVICE_ATTR(fan6_speed, S_IRUGO, show_fan_speed, NULL, FAN6_REG);
+static SENSOR_DEVICE_ATTR(fan7_speed, S_IRUGO, show_fan_speed, NULL, FAN7_REG);
+static SENSOR_DEVICE_ATTR(fan8_speed, S_IRUGO, show_fan_speed, NULL, FAN8_REG);
+
+static struct attribute *fan_cpld_attributes[] = {
+    &sensor_dev_attr_code_ver.dev_attr.attr,
+    &sensor_dev_attr_board_ver.dev_attr.attr,
+    &sensor_dev_attr_scratch.dev_attr.attr,
+    &sensor_dev_attr_fan1_led.dev_attr.attr,
+    &sensor_dev_attr_fan2_led.dev_attr.attr,
+    &sensor_dev_attr_fan3_led.dev_attr.attr,
+    &sensor_dev_attr_fan4_led.dev_attr.attr,
+    &sensor_dev_attr_fan1_present.dev_attr.attr,
+    &sensor_dev_attr_fan2_present.dev_attr.attr,
+    &sensor_dev_attr_fan3_present.dev_attr.attr,
+    &sensor_dev_attr_fan4_present.dev_attr.attr,
+    &sensor_dev_attr_fan1_power.dev_attr.attr,
+    &sensor_dev_attr_fan2_power.dev_attr.attr,
+    &sensor_dev_attr_fan3_power.dev_attr.attr,
+    &sensor_dev_attr_fan4_power.dev_attr.attr,
+    &sensor_dev_attr_pwm1.dev_attr.attr,
+    &sensor_dev_attr_pwm2.dev_attr.attr,
+    &sensor_dev_attr_pwm3.dev_attr.attr,
+    &sensor_dev_attr_pwm4.dev_attr.attr,
+    &sensor_dev_attr_pwm5.dev_attr.attr,
+    &sensor_dev_attr_pwm6.dev_attr.attr,
+    &sensor_dev_attr_pwm7.dev_attr.attr,
+    &sensor_dev_attr_pwm8.dev_attr.attr,
+    &sensor_dev_attr_fan1_speed.dev_attr.attr,
+    &sensor_dev_attr_fan2_speed.dev_attr.attr,
+    &sensor_dev_attr_fan3_speed.dev_attr.attr,
+    &sensor_dev_attr_fan4_speed.dev_attr.attr,
+    &sensor_dev_attr_fan5_speed.dev_attr.attr,
+    &sensor_dev_attr_fan6_speed.dev_attr.attr,
+    &sensor_dev_attr_fan7_speed.dev_attr.attr,
+    &sensor_dev_attr_fan8_speed.dev_attr.attr,
+  
+    NULL
+};
+
+static const struct attribute_group fan_cpld_group = {
+    .attrs = fan_cpld_attributes,
+};
+
+static int fan_cpld_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+     struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia FAN CPLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &fan_cpld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    data->code_major_ver = cpld_i2c_read(data, MAJOR_REV_REG);
+    data->code_minor_ver = cpld_i2c_read(data, MINOR_REV_REG);
+    data->board_ver = (cpld_i2c_read(data, PCB_VERSION_REG))& BOARD_INFO_REG_TYPE_MSK;
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void fan_cpld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &fan_cpld_group);
+    kfree(data);
+}
+
+static const struct of_device_id fan_cpld_of_ids[] = {
+    {
+        .compatible = "nokia,fan_cpld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, fan_cpld_of_ids);
+
+static const struct i2c_device_id fan_cpld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, fan_cpld_ids);
+
+static struct i2c_driver fan_cpld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(fan_cpld_of_ids),
+    },
+    .probe        = fan_cpld_probe,
+    .remove       = fan_cpld_remove,
+    .id_table     = fan_cpld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init fan_cpld_init(void)
+{
+    return i2c_add_driver(&fan_cpld_driver);
+}
+
+static void __exit fan_cpld_exit(void)
+{
+    i2c_del_driver(&fan_cpld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA FAN CPLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(fan_cpld_init);
+module_exit(fan_cpld_exit);

--- a/ixr7220h4-64d/modules/pdbl_cpld.c
+++ b/ixr7220h4-64d/modules/pdbl_cpld.c
@@ -1,0 +1,176 @@
+//  * PDB_L CPLD driver 
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  * 
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+// 
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "pdbl_cpld"
+
+// REGISTERS ADDRESS MAP
+#define MINOR_REV_REG               0x00
+#define MAJOR_REV_REG               0x01
+
+static const unsigned short cpld_address_list[] = {0x60, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int code_major_ver;
+    int code_minor_ver;    
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+static ssize_t show_code_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%d.%d\n", data->code_major_ver, data->code_minor_ver);
+}
+
+// sysfs attributes 
+static SENSOR_DEVICE_ATTR(code_ver, S_IRUGO, show_code_ver, NULL, 0);
+
+static struct attribute *pdbl_cpld_attributes[] = {
+    &sensor_dev_attr_code_ver.dev_attr.attr,    
+    NULL
+};
+
+static const struct attribute_group pdbl_cpld_group = {
+    .attrs = pdbl_cpld_attributes,
+};
+
+static int pdbl_cpld_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+     struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia PDB_L CPLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &pdbl_cpld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    data->code_major_ver = cpld_i2c_read(data, MAJOR_REV_REG);
+    data->code_minor_ver = cpld_i2c_read(data, MINOR_REV_REG); 
+    return 0;
+
+exit:
+    return status;
+}
+
+static void pdbl_cpld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &pdbl_cpld_group);
+    kfree(data);
+}
+
+static const struct of_device_id pdbl_cpld_of_ids[] = {
+    {
+        .compatible = "nokia,pdbl_cpld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, pdbl_cpld_of_ids);
+
+static const struct i2c_device_id pdbl_cpld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, pdbl_cpld_ids);
+
+static struct i2c_driver pdbl_cpld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(pdbl_cpld_of_ids),
+    },
+    .probe        = pdbl_cpld_probe,
+    .remove       = pdbl_cpld_remove,
+    .id_table     = pdbl_cpld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init pdbl_cpld_init(void)
+{
+    return i2c_add_driver(&pdbl_cpld_driver);
+}
+
+static void __exit pdbl_cpld_exit(void)
+{
+    i2c_del_driver(&pdbl_cpld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA PDB_L CPLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(pdbl_cpld_init);
+module_exit(pdbl_cpld_exit);

--- a/ixr7220h4-64d/modules/pdbr_cpld.c
+++ b/ixr7220h4-64d/modules/pdbr_cpld.c
@@ -1,0 +1,177 @@
+//  * PDB_R CPLD driver
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  * 
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+// 
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "pdbr_cpld"
+
+// REGISTERS ADDRESS MAP
+#define MINOR_REV_REG               0x00
+#define MAJOR_REV_REG               0x01
+
+static const unsigned short cpld_address_list[] = {0x60, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int code_major_ver;
+    int code_minor_ver;
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+static ssize_t show_code_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%d.%d\n", data->code_major_ver, data->code_minor_ver);
+}
+
+// sysfs attributes 
+static SENSOR_DEVICE_ATTR(code_ver, S_IRUGO, show_code_ver, NULL, 0);
+
+
+static struct attribute *pdbr_cpld_attributes[] = {
+    &sensor_dev_attr_code_ver.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group pdbr_cpld_group = {
+    .attrs = pdbr_cpld_attributes,
+};
+
+static int pdbr_cpld_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+     struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia PDB_R CPLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &pdbr_cpld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    data->code_major_ver = cpld_i2c_read(data, MAJOR_REV_REG);
+    data->code_minor_ver = cpld_i2c_read(data, MINOR_REV_REG);
+    return 0;
+
+exit:
+    return status;
+}
+
+static void pdbr_cpld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &pdbr_cpld_group);
+    kfree(data);
+}
+
+static const struct of_device_id pdbr_cpld_of_ids[] = {
+    {
+        .compatible = "nokia,pdbr_cpld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, pdbr_cpld_of_ids);
+
+static const struct i2c_device_id pdbr_cpld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, pdbr_cpld_ids);
+
+static struct i2c_driver pdbr_cpld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(pdbr_cpld_of_ids),
+    },
+    .probe        = pdbr_cpld_probe,
+    .remove       = pdbr_cpld_remove,
+    .id_table     = pdbr_cpld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init pdbr_cpld_init(void)
+{
+    return i2c_add_driver(&pdbr_cpld_driver);
+}
+
+static void __exit pdbr_cpld_exit(void)
+{
+    i2c_del_driver(&pdbr_cpld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA PDB_R CPLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(pdbr_cpld_init);
+module_exit(pdbr_cpld_exit);

--- a/ixr7220h4-64d/modules/scm_cpld.c
+++ b/ixr7220h4-64d/modules/scm_cpld.c
@@ -1,0 +1,246 @@
+//  * SCM CPLD driver
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  * 
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+// 
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "scm_cpld"
+
+// REGISTERS ADDRESS MAP
+#define MINOR_REV_REG               0x00
+#define MAJOR_REV_REG               0x01
+#define HW_REV_REG                  0x02
+#define SCRATCH_REG                 0x04
+#define RST_CAUSE_CTRL_REG          0x2F
+#define RST_CAUSE_REG               0x52
+
+// REG BIT FIELD POSITION or MASK
+#define HW_REV_REG_BRDID_MSK        0xF
+#define HW_REV_REG_PCB_VER          0x4
+
+static const unsigned short cpld_address_list[] = {0x35, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int code_major_ver;
+    int code_minor_ver;
+    int pcb_ver;  
+    int board_id;
+    int reset_cause;
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+static ssize_t show_code_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%d.%d\n", data->code_major_ver, data->code_minor_ver);
+}
+
+static ssize_t show_board_id(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);    
+    return sprintf(buf, "0x%02x\n", data->board_id);
+}
+
+static ssize_t show_pcb_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);    
+    return sprintf(buf, "0x%02x\n", data->pcb_ver);
+}
+
+static ssize_t show_scratch(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+      
+    val = cpld_i2c_read(data, SCRATCH_REG);
+
+    return sprintf(buf, "%02x\n", val);
+}
+
+static ssize_t set_scratch(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 0xFF) {
+        return -EINVAL;
+    }
+
+    cpld_i2c_write(data, SCRATCH_REG, usr_val);
+
+    return count;
+}
+
+static ssize_t show_rst_cause(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%02x\n", data->reset_cause);
+}
+
+// sysfs attributes 
+static SENSOR_DEVICE_ATTR(code_ver, S_IRUGO, show_code_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(board_id, S_IRUGO, show_board_id, NULL, 0);
+static SENSOR_DEVICE_ATTR(pcb_ver, S_IRUGO, show_pcb_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(scratch, S_IRUGO | S_IWUSR, show_scratch, set_scratch, 0);
+static SENSOR_DEVICE_ATTR(reset_cause, S_IRUGO, show_rst_cause, NULL, 0);
+
+static struct attribute *scm_cpld_attributes[] = {
+    &sensor_dev_attr_code_ver.dev_attr.attr,
+    &sensor_dev_attr_board_id.dev_attr.attr,
+    &sensor_dev_attr_pcb_ver.dev_attr.attr,
+    &sensor_dev_attr_scratch.dev_attr.attr,
+    &sensor_dev_attr_reset_cause.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group scm_cpld_group = {
+    .attrs = scm_cpld_attributes,
+};
+
+static int scm_cpld_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+     struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia SCM CPLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &scm_cpld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    data->code_major_ver = cpld_i2c_read(data, MAJOR_REV_REG);
+    data->code_minor_ver = cpld_i2c_read(data, MINOR_REV_REG);
+    data->board_id = cpld_i2c_read(data, HW_REV_REG) & HW_REV_REG_BRDID_MSK;
+    data->pcb_ver = cpld_i2c_read(data, HW_REV_REG) >> HW_REV_REG_PCB_VER;
+    data->reset_cause = cpld_i2c_read(data, RST_CAUSE_REG);
+    cpld_i2c_write(data, RST_CAUSE_CTRL_REG, 0x1);
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void scm_cpld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &scm_cpld_group);
+    kfree(data);
+}
+
+static const struct of_device_id scm_cpld_of_ids[] = {
+    {
+        .compatible = "nokia,scm_cpld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, scm_cpld_of_ids);
+
+static const struct i2c_device_id scm_cpld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, scm_cpld_ids);
+
+static struct i2c_driver scm_cpld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(scm_cpld_of_ids),
+    },
+    .probe        = scm_cpld_probe,
+    .remove       = scm_cpld_remove,
+    .id_table     = scm_cpld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init scm_cpld_init(void)
+{
+    return i2c_add_driver(&scm_cpld_driver);
+}
+
+static void __exit scm_cpld_exit(void)
+{
+    i2c_del_driver(&scm_cpld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA SCM CPLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(scm_cpld_init);
+module_exit(scm_cpld_exit);

--- a/ixr7220h4-64d/modules/smb_cpld.c
+++ b/ixr7220h4-64d/modules/smb_cpld.c
@@ -1,0 +1,292 @@
+//  * SMB CPLD driver
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  * 
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+// 
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "smb_cpld"
+
+// REGISTERS ADDRESS MAP
+#define MINOR_REV_REG               0x00
+#define MAJOR_REV_REG               0x01
+#define HW_REV_REG                  0x02
+#define SCRATCH_REG                 0x04
+#define USB_REG                     0x10
+#define PRS_SIG_REG                 0x14
+#define PWR_LED_REG                 0x18
+#define SYS_STAT_REG                0x19
+#define PSU_GOOD_REG                0x90
+
+
+
+// REG BIT FIELD POSITION or MASK
+#define HW_REV_REG_BRDID_MSK        0xF
+#define HW_REV_REG_PCB_VER          0x4
+
+#define PRS_SIG_REG_PSU_R           0x0
+#define PRS_SIG_REG_PSU_L           0x1
+
+#define SYS_STAT_REG_PSU_L_OK       0x0
+#define SYS_STAT_REG_PSU_R_OK       0x2
+
+#define PSU_GOOD_REG_PSU_L_OK       0x0
+#define PSU_GOOD_REG_PSU_R_OK       0x1
+
+static const unsigned short cpld_address_list[] = {0x60, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int code_major_ver;
+    int code_minor_ver;
+    int pcb_ver;  
+    int board_id;
+    int reset_cause;
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+static ssize_t show_code_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%d.%d\n", data->code_major_ver, data->code_minor_ver);
+}
+
+static ssize_t show_board_id(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);    
+    return sprintf(buf, "0x%02x\n", data->board_id);
+}
+
+static ssize_t show_pcb_ver(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);    
+    return sprintf(buf, "0x%02x\n", data->pcb_ver);
+}
+
+static ssize_t show_scratch(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+      
+    val = cpld_i2c_read(data, SCRATCH_REG);
+
+    return sprintf(buf, "%02x\n", val);
+}
+
+static ssize_t set_scratch(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 0xFF) {
+        return -EINVAL;
+    }
+
+    cpld_i2c_write(data, SCRATCH_REG, usr_val);
+
+    return count;
+}
+
+static ssize_t show_present(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, PRS_SIG_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t show_sys_stat(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYS_STAT_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t show_psu_good(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, PSU_GOOD_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+// sysfs attributes 
+static SENSOR_DEVICE_ATTR(code_ver, S_IRUGO, show_code_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(board_id, S_IRUGO, show_board_id, NULL, 0);
+static SENSOR_DEVICE_ATTR(pcb_ver, S_IRUGO, show_pcb_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(scratch, S_IRUGO | S_IWUSR, show_scratch, set_scratch, 0);
+static SENSOR_DEVICE_ATTR(psu1_present, S_IRUGO, show_present, NULL, PRS_SIG_REG_PSU_R);
+static SENSOR_DEVICE_ATTR(psu2_present, S_IRUGO, show_present, NULL, PRS_SIG_REG_PSU_L);
+static SENSOR_DEVICE_ATTR(psu1_state, S_IRUGO, show_sys_stat, NULL, SYS_STAT_REG_PSU_R_OK);
+static SENSOR_DEVICE_ATTR(psu2_state, S_IRUGO, show_sys_stat, NULL, SYS_STAT_REG_PSU_L_OK);
+static SENSOR_DEVICE_ATTR(psu1_pwr_ok, S_IRUGO, show_psu_good, NULL, PSU_GOOD_REG_PSU_R_OK);
+static SENSOR_DEVICE_ATTR(psu2_pwr_ok, S_IRUGO, show_psu_good, NULL, PSU_GOOD_REG_PSU_L_OK);
+
+static struct attribute *smb_cpld_attributes[] = {
+    &sensor_dev_attr_code_ver.dev_attr.attr,
+    &sensor_dev_attr_board_id.dev_attr.attr,
+    &sensor_dev_attr_pcb_ver.dev_attr.attr,
+    &sensor_dev_attr_scratch.dev_attr.attr,
+    &sensor_dev_attr_psu1_present.dev_attr.attr,
+    &sensor_dev_attr_psu2_present.dev_attr.attr,
+    &sensor_dev_attr_psu1_state.dev_attr.attr,
+    &sensor_dev_attr_psu2_state.dev_attr.attr,
+    &sensor_dev_attr_psu1_pwr_ok.dev_attr.attr,
+    &sensor_dev_attr_psu2_pwr_ok.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group smb_cpld_group = {
+    .attrs = smb_cpld_attributes,
+};
+
+static int smb_cpld_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+     struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia SMB CPLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &smb_cpld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    data->code_major_ver = cpld_i2c_read(data, MAJOR_REV_REG);
+    data->code_minor_ver = cpld_i2c_read(data, MINOR_REV_REG);
+    data->board_id = cpld_i2c_read(data, HW_REV_REG) & HW_REV_REG_BRDID_MSK;
+    data->pcb_ver = cpld_i2c_read(data, HW_REV_REG) >> HW_REV_REG_PCB_VER;
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void smb_cpld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &smb_cpld_group);
+    kfree(data);
+}
+
+static const struct of_device_id smb_cpld_of_ids[] = {
+    {
+        .compatible = "nokia,smb_cpld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, smb_cpld_of_ids);
+
+static const struct i2c_device_id smb_cpld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, smb_cpld_ids);
+
+static struct i2c_driver smb_cpld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(smb_cpld_of_ids),
+    },
+    .probe        = smb_cpld_probe,
+    .remove       = smb_cpld_remove,
+    .id_table     = smb_cpld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init smb_cpld_init(void)
+{
+    return i2c_add_driver(&smb_cpld_driver);
+}
+
+static void __exit smb_cpld_exit(void)
+{
+    i2c_del_driver(&smb_cpld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA SMB CPLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(smb_cpld_init);
+module_exit(smb_cpld_exit);

--- a/ixr7220h4-64d/modules/sys_fpga.c
+++ b/ixr7220h4-64d/modules/sys_fpga.c
@@ -1,0 +1,2779 @@
+//
+//  * Copyright (C) 2024 Nokia Corporation.
+//  *
+//  * 
+//  * Based on:
+//  *    optoe.c fromDON BOLLINGER <don@thebollingers.org>
+//  * Copyright (C) 2017 Finisar Corp.
+//  *
+//  * This file is licensed under the terms of the GNU General Public
+//  * License version 2. This program is licensed "as is" without any
+//  * warranty of any kind, whether express or implied.
+// 
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/slab.h>
+#include <linux/device.h>
+#include <linux/platform_device.h>
+#include <linux/i2c.h>
+#include <linux/mutex.h>
+#include <linux/interrupt.h>
+#include <linux/i2c-mux.h>
+#include <linux/version.h>
+#include <linux/stat.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/delay.h>
+#include <linux/pci.h>
+#include <linux/time64.h>
+#include <linux/delay.h>
+
+/***********************************************
+ *       variable define
+ * *********************************************/
+#define DRVNAME               "sys_fpga"
+/*
+ * PCIE BAR0 address of UDB and LDB
+ */
+#define BAR0_NUM                      0
+#define PCI_VENDOR_ID_ACCTON          0x1113
+#define PCI_DEVICE_ID_ACCTON          0x8664
+#define PCI_SUBSYSTEM_ID_UDB          0x0000
+#define PCI_SUBSYSTEM_ID_LDB          0x0001
+#define PCI_SUBSYSTEM_ID_SMB          0x0002
+
+#define QSFP_PRESENT_REG_OFFSET       0x1500
+#define QSFP_LPMODE_REG_OFFSET        0x1550
+#define QSFP_RESET_REG_OFFSET         0x1560
+
+#define SFP_LDB_GPIO1_DATA_EN         0x1000
+#define SFP_LDB_GPIO1_DATA_OUT        0x1004
+#define SFP_LDB_GPIO1_DATA_IN         0x1008
+
+#define ASLPC_DEV_UDB_CPLD1_PCIE_START_OFFST 0x400
+#define ASLPC_DEV_UDB_CPLD2_PCIE_START_OFFST 0x500
+#define ASLPC_DEV_LDB_CPLD1_PCIE_START_OFFST 0x400
+#define ASLPC_DEV_LDB_CPLD2_PCIE_START_OFFST 0x500
+#define ASLPC_DEV_SMB_CPLD_PCIE_START_OFFST  0x200
+
+#define UDB_CPLD2_FP_LED_SYS2         0x0510
+
+#define   BIT(x)                      x
+#define   SFP_PORT0_TXDIS(x)          ((x) >> (11))
+#define   SFP_PORT0_ABS(x)            ((x) >> (10))
+#define   SFP_PORT0_TXFLT(x)          ((x) >> (9))
+#define   SFP_PORT0_RXLOS(x)          ((x) >> (8))
+#define   SFP_PORT1_TXDIS(x)          ((x) >> (3))
+#define   SFP_PORT1_ABS(x)            ((x) >> (2))
+#define   SFP_PORT1_TXFLT(x)          ((x) >> (1))
+#define   SFP_PORT1_RXLOS(x)          ((x) >> (0))
+
+#define QSFP_NUM_OF_PORT 64
+#define SFP_NUM_OF_PORT  2
+#define FPGA_NUM 3
+
+#define TRANSCEIVER_PRESENT_ATTR_ID(index)    MODULE_PRESENT_##index
+#define TRANSCEIVER_LPMODE_ATTR_ID(index)     MODULE_LPMODE_##index
+#define TRANSCEIVER_RESET_ATTR_ID(index)      MODULE_RESET_##index
+#define TRANSCEIVER_TX_DISABLE_ATTR_ID(index) MODULE_TX_DISABLE_##index
+#define TRANSCEIVER_TX_FAULT_ATTR_ID(index)   MODULE_TX_FAULT_##index
+#define TRANSCEIVER_RX_LOS_ATTR_ID(index)     MODULE_RX_LOS_##index
+
+/*
+ *PCIE port dev define
+ */
+#define EEPROM_SYSFS_NAME     "eeprom"
+
+#define FPGA_UDB_QSFP_PORT_NUM  32
+#define FPGA_LDB_QSFP_PORT_NUM  32
+#define FPGA_QSFP_PORT_NUM      (FPGA_UDB_QSFP_PORT_NUM + FPGA_LDB_QSFP_PORT_NUM)
+#define FPGA_LDB_SFP_PORT1_NO   65
+#define FPGA_LDB_SFP_PORT2_NO   66
+#define FPGA_LDB_SFP_PORT_NUM   2
+
+#define QSFPDD_TYPE     0x18
+/* fundamental unit of addressing for EEPROM */
+#define OPTOE_PAGE_SIZE 128
+/*
+ * Single address devices (eg QSFP, CMIS) have 256 pages, plus the unpaged
+ * low 128 bytes.  If the device does not support paging, it is
+ * only 2 'pages' long.
+ */
+#define OPTOE_ARCH_PAGES 256
+#define ONE_ADDR_EEPROM_SIZE ((1 + OPTOE_ARCH_PAGES) * OPTOE_PAGE_SIZE)
+#define ONE_ADDR_EEPROM_UNPAGED_SIZE (2 * OPTOE_PAGE_SIZE)
+/*
+ * Dual address devices (eg SFP) have 256 pages, plus the unpaged
+ * low 128 bytes, plus 256 bytes at 0x50.  If the device does not
+ * support paging, it is 4 'pages' long.
+ */
+#define TWO_ADDR_EEPROM_SIZE ((3 + OPTOE_ARCH_PAGES) * OPTOE_PAGE_SIZE)
+#define TWO_ADDR_EEPROM_UNPAGED_SIZE (4 * OPTOE_PAGE_SIZE)
+#define TWO_ADDR_NO_0X51_SIZE (2 * OPTOE_PAGE_SIZE)
+
+/* a few constants to find our way around the EEPROM */
+#define OPTOE_PAGE_SELECT_REG   0x7F
+#define ONE_ADDR_PAGEABLE_REG   0x02
+#define QSFP_NOT_PAGEABLE      (1<<2)
+#define CMIS_NOT_PAGEABLE      (1<<7)
+#define TWO_ADDR_PAGEABLE_REG   0x40
+#define TWO_ADDR_PAGEABLE      (1<<4)
+#define TWO_ADDR_0X51_REG       92
+#define TWO_ADDR_0X51_SUPP     (1<<6)
+#define OPTOE_READ_OP           0
+#define OPTOE_WRITE_OP          1
+#define OPTOE_EOF               0  /* used for access beyond end of device */
+#define TWO_ADDR_0X51           0x51
+#define EEPROM_ALLOW_SET_LEN    1
+
+/*
+ * flags to distinguish one-address (QSFP family) from two-address (SFP family)
+ * and one-address Common Management Interface Specification (CMIS family)
+ */
+#define ONE_ADDR 1
+#define TWO_ADDR 2
+#define CMIS_ADDR 3
+
+/* I2C Controller Management Registers */
+#define PCIE_FPGA_I2C_MGMT_RTC0_PROFILE_0         0x2008
+
+/* I2C Real Time Control Registers */
+#define PCIE_FPGA_I2C_CONTROL_RTC0_CONFIG_0       0x2050
+#define PCIE_FPGA_I2C_CONTROL_RTC0_CONFIG_1       0x2054
+#define PCIE_FPGA_I2C_CONTROL_RTC0_STATUS_0       0x2060
+
+/* I2C RTC Data Block */
+#define PCIE_FPGA_I2C_RTC_WRITE_DATA_REG_0        0x5000
+#define PCIE_FPGA_I2C_RTC_READ_DATA_REG_0         0xA000
+
+#define PCIE_FPGA_I2C_MAX_LEN                     128
+#define PCIE_FPGA_I2C_NEW_TRIGGER_VALUE           0x80000000
+
+/* Show system date time */
+#define DATETIME_LEN  50
+char g_datetime[DATETIME_LEN];
+
+/***********************************************
+ *       structure & variable declare
+ * *********************************************/
+static char FPGA_NAME[FPGA_NUM][10] = {"UDB FPGA", "LDB FPGA", "SMB FPGA"};
+
+typedef struct pci_fpga_device_s {
+	struct pci_dev  *fpga_pdev;
+	void  __iomem *data_base_addr;
+	resource_size_t data_mmio_start;
+	resource_size_t data_mmio_len;
+	u16  id;
+	u32  qsfp_present;
+	u32  qsfp_lpmode;
+	u32  qsfp_reset;
+	u32  sfp_input_data;
+	u32  sfp_output_data;
+	u16  aslpc_cpld1_offset;
+	u16  aslpc_cpld2_offset;
+} pci_fpga_device_t;
+
+/*fpga port status*/
+struct sys_fpga_data {
+	struct platform_device    *pdev;
+	struct pci_dev            *pci_dev_addr[FPGA_NUM];  /*UDB, LDB and SMB*/
+	pci_fpga_device_t         pci_fpga_dev[FPGA_NUM];   /*UDB, LDB and SMB*/
+	u32                       udb_version;
+	u32                       ldb_version;
+	u32                       smb_version;
+	unsigned long             last_updated;    /* In jiffies */
+	int                       reset_list[QSFP_NUM_OF_PORT];
+	u32                       udb_cpld1_ver;
+	u32                       udb_cpld2_ver;
+	u32                       ldb_cpld1_ver;
+	u32                       ldb_cpld2_ver;
+};
+
+static struct sys_fpga_data  *fpga_ctl = NULL;
+
+struct mutex update_lock;
+
+struct eeprom_bin_private_data {
+	int    port_num;
+	int    fpga_type;
+	int    pageable;
+	int    sfp_support_a2;
+	int    i2c_slave_addr;
+	int    i2c_mgmt_rtc0_profile;
+	int    i2c_contrl_rtc0_config_0;
+	int    i2c_contrl_rtc0_config_1;
+	int    i2c_contrl_rtc0_stats;
+	int    i2c_rtc_read_data;
+	int    i2c_rtc_write_data;
+	void   __iomem *data_base_addr;
+};
+
+struct pcie_fpga_dev_platform_data {
+	int    port_num;
+	char   name[10];      /*ex: port1*/
+	char   dev_name[10];  /*ex: optoe1*/
+	int    dev_class;
+	int    fpga_type;
+	struct bin_attribute eeprom_bin;
+};
+
+/***********************************************
+ *       macro define
+ * *********************************************/
+#define pcie_err(fmt, args...) \
+	printk(KERN_ERR "[sys_fpga_driver]: " fmt " ", ##args)
+
+#define pcie_info(fmt, args...) \
+	printk(KERN_INFO "[sys_fpga_driver]: " fmt " ", ##args)
+
+/* UDB */
+ /*c from 0 to 31*/
+#define pcie_udb_qsfp_device_port(c){                                    \
+	.name                   = "pcie_udb_fpga_device",                \
+	.id                     = c,                                     \
+	.dev                    = {                                      \
+		.platform_data 		= &pcie_udb_dev_platform_data[c],\
+		.release 		= device_release,                \
+	},                                                               \
+}
+ /*c from 1*/
+#define pcie_udb_qsfp_platform_data_init(c){                             \
+	.port_num                   = c,                                 \
+	.dev_name                   = "optoe1",                          \
+	.dev_class                  = 1,                                 \
+	.fpga_type = PCIE_FPGA_TYPE_UDB,                                 \
+	.eeprom_bin                 = {                                  \
+		.private = &pcie_udb_eeprom_bin_private_data[c-1],	 \
+	},                                                               \
+}
+ /*c from 1*/
+#define eeprom_udb_private_data_port_init(c){                            \
+	.port_num                    = c,                                \
+	.fpga_type                   = PCIE_FPGA_TYPE_UDB,               \
+	.i2c_slave_addr              = 0x50,                             \
+	.i2c_mgmt_rtc0_profile       = PCIE_FPGA_I2C_MGMT_RTC0_PROFILE_0   + 0x100*(c-1),     \
+	.i2c_contrl_rtc0_config_0    = PCIE_FPGA_I2C_CONTROL_RTC0_CONFIG_0 + 0x100*(c-1),     \
+	.i2c_contrl_rtc0_config_1    = PCIE_FPGA_I2C_CONTROL_RTC0_CONFIG_1 + 0x100*(c-1),     \
+	.i2c_contrl_rtc0_stats       = PCIE_FPGA_I2C_CONTROL_RTC0_STATUS_0 + 0x100*(c-1),     \
+	.i2c_rtc_read_data           = PCIE_FPGA_I2C_RTC_READ_DATA_REG_0   + 0x200*(c-1),     \
+	.i2c_rtc_write_data          = PCIE_FPGA_I2C_RTC_WRITE_DATA_REG_0  + 0x200*(c-1),     \
+}
+
+/* LDB */
+/*c from 0 to 31*/
+#define pcie_ldb_qsfp_device_port(c){                                    \
+	.name                   = "pcie_ldb_fpga_device",                \
+	.id                     = c,                                     \
+	.dev                    = {                                      \
+		.platform_data  = &pcie_ldb_dev_platform_data[c],	 \
+		.release        = device_release,                        \
+	},                                                               \
+}
+
+/*c from 32 to 33*/
+#define pcie_ldb_sfp_device_port(c){                                     \
+	.name                   = "pcie_ldb_fpga_device",                \
+	.id                     = c,                                     \
+	.dev                    = {                                      \
+		.platform_data  = &pcie_ldb_dev_platform_data[c],        \
+		.release        = device_release,                        \
+	},                                                               \
+}
+
+/*c from 1 to 32*/
+#define pcie_ldb_qsfp_platform_data_init(c){                             \
+	.port_num                   = c,                                 \
+	.dev_name                   = "optoe1",                          \
+	.dev_class                  = 1,                                 \
+	.fpga_type = PCIE_FPGA_TYPE_LDB,                                 \
+	.eeprom_bin                 = {                                  \
+		.private = &pcie_ldb_eeprom_bin_private_data[c-1],	 \
+	},                                                               \
+}
+
+/*c = 33, 34*/
+#define pcie_ldb_sfp_platform_data_init(c){                              \
+	.port_num                   = c,                                 \
+	.dev_name                   = "optoe2",                          \
+	.dev_class                  = 2,                                 \
+	.fpga_type = PCIE_FPGA_TYPE_LDB,                                 \
+	.eeprom_bin                 = {                                  \
+		.private = &pcie_ldb_eeprom_bin_private_data[c-1],	 \
+	},                                                               \
+}
+
+/*c from 1 to 32, 33, 34*/
+#define eeprom_ldb_private_data_port_init(c){                                                 \
+	.port_num                    = c + 32,                                                \
+	.fpga_type                   = PCIE_FPGA_TYPE_LDB,                                    \
+	.i2c_slave_addr              = 0x50,                                                  \
+	.i2c_mgmt_rtc0_profile       = PCIE_FPGA_I2C_MGMT_RTC0_PROFILE_0   + 0x100*(c-1),     \
+	.i2c_contrl_rtc0_config_0    = PCIE_FPGA_I2C_CONTROL_RTC0_CONFIG_0 + 0x100*(c-1),     \
+	.i2c_contrl_rtc0_config_1    = PCIE_FPGA_I2C_CONTROL_RTC0_CONFIG_1 + 0x100*(c-1),     \
+	.i2c_contrl_rtc0_stats       = PCIE_FPGA_I2C_CONTROL_RTC0_STATUS_0 + 0x100*(c-1),     \
+	.i2c_rtc_read_data           = PCIE_FPGA_I2C_RTC_READ_DATA_REG_0   + 0x200*(c-1),     \
+	.i2c_rtc_write_data          = PCIE_FPGA_I2C_RTC_WRITE_DATA_REG_0  + 0x200*(c-1),     \
+}
+
+/***********************************************
+ *       enum define
+ * *********************************************/
+enum fpga_type_t {
+	PCIE_FPGA_UDB = 0,
+	PCIE_FPGA_LDB,
+	PCIE_FPGA_SMB
+};
+
+enum fpga_set_function_type_t {
+	PCIE_FPGA_SET_LPMODE,
+	PCIE_FPGA_SET_RESET,
+	PCIE_FPGA_SET_TX_DISABLE
+};
+
+enum fpga_sysfs_attributes {
+	MODULE_PRESENT_ALL,
+	MODULE_RXLOS_ALL,
+	/* transceiver attributes */
+	TRANSCEIVER_PRESENT_ATTR_ID(1),
+	TRANSCEIVER_PRESENT_ATTR_ID(2),
+	TRANSCEIVER_PRESENT_ATTR_ID(3),
+	TRANSCEIVER_PRESENT_ATTR_ID(4),
+	TRANSCEIVER_PRESENT_ATTR_ID(5),
+	TRANSCEIVER_PRESENT_ATTR_ID(6),
+	TRANSCEIVER_PRESENT_ATTR_ID(7),
+	TRANSCEIVER_PRESENT_ATTR_ID(8),
+	TRANSCEIVER_PRESENT_ATTR_ID(9),
+	TRANSCEIVER_PRESENT_ATTR_ID(10),
+	TRANSCEIVER_PRESENT_ATTR_ID(11),
+	TRANSCEIVER_PRESENT_ATTR_ID(12),
+	TRANSCEIVER_PRESENT_ATTR_ID(13),
+	TRANSCEIVER_PRESENT_ATTR_ID(14),
+	TRANSCEIVER_PRESENT_ATTR_ID(15),
+	TRANSCEIVER_PRESENT_ATTR_ID(16),
+	TRANSCEIVER_PRESENT_ATTR_ID(17),
+	TRANSCEIVER_PRESENT_ATTR_ID(18),
+	TRANSCEIVER_PRESENT_ATTR_ID(19),
+	TRANSCEIVER_PRESENT_ATTR_ID(20),
+	TRANSCEIVER_PRESENT_ATTR_ID(21),
+	TRANSCEIVER_PRESENT_ATTR_ID(22),
+	TRANSCEIVER_PRESENT_ATTR_ID(23),
+	TRANSCEIVER_PRESENT_ATTR_ID(24),
+	TRANSCEIVER_PRESENT_ATTR_ID(25),
+	TRANSCEIVER_PRESENT_ATTR_ID(26),
+	TRANSCEIVER_PRESENT_ATTR_ID(27),
+	TRANSCEIVER_PRESENT_ATTR_ID(28),
+	TRANSCEIVER_PRESENT_ATTR_ID(29),
+	TRANSCEIVER_PRESENT_ATTR_ID(30),
+	TRANSCEIVER_PRESENT_ATTR_ID(31),
+	TRANSCEIVER_PRESENT_ATTR_ID(32),
+	TRANSCEIVER_PRESENT_ATTR_ID(33),
+	TRANSCEIVER_PRESENT_ATTR_ID(34),
+	TRANSCEIVER_PRESENT_ATTR_ID(35),
+	TRANSCEIVER_PRESENT_ATTR_ID(36),
+	TRANSCEIVER_PRESENT_ATTR_ID(37),
+	TRANSCEIVER_PRESENT_ATTR_ID(38),
+	TRANSCEIVER_PRESENT_ATTR_ID(39),
+	TRANSCEIVER_PRESENT_ATTR_ID(40),
+	TRANSCEIVER_PRESENT_ATTR_ID(41),
+	TRANSCEIVER_PRESENT_ATTR_ID(42),
+	TRANSCEIVER_PRESENT_ATTR_ID(43),
+	TRANSCEIVER_PRESENT_ATTR_ID(44),
+	TRANSCEIVER_PRESENT_ATTR_ID(45),
+	TRANSCEIVER_PRESENT_ATTR_ID(46),
+	TRANSCEIVER_PRESENT_ATTR_ID(47),
+	TRANSCEIVER_PRESENT_ATTR_ID(48),
+	TRANSCEIVER_PRESENT_ATTR_ID(49),
+	TRANSCEIVER_PRESENT_ATTR_ID(50),
+	TRANSCEIVER_PRESENT_ATTR_ID(51),
+	TRANSCEIVER_PRESENT_ATTR_ID(52),
+	TRANSCEIVER_PRESENT_ATTR_ID(53),
+	TRANSCEIVER_PRESENT_ATTR_ID(54),
+	TRANSCEIVER_PRESENT_ATTR_ID(55),
+	TRANSCEIVER_PRESENT_ATTR_ID(56),
+	TRANSCEIVER_PRESENT_ATTR_ID(57),
+	TRANSCEIVER_PRESENT_ATTR_ID(58),
+	TRANSCEIVER_PRESENT_ATTR_ID(59),
+	TRANSCEIVER_PRESENT_ATTR_ID(60),
+	TRANSCEIVER_PRESENT_ATTR_ID(61),
+	TRANSCEIVER_PRESENT_ATTR_ID(62),
+	TRANSCEIVER_PRESENT_ATTR_ID(63),
+	TRANSCEIVER_PRESENT_ATTR_ID(64),
+	TRANSCEIVER_PRESENT_ATTR_ID(65),
+	TRANSCEIVER_PRESENT_ATTR_ID(66),
+	/*Reset*/
+	TRANSCEIVER_RESET_ATTR_ID(1),
+	TRANSCEIVER_RESET_ATTR_ID(2),
+	TRANSCEIVER_RESET_ATTR_ID(3),
+	TRANSCEIVER_RESET_ATTR_ID(4),
+	TRANSCEIVER_RESET_ATTR_ID(5),
+	TRANSCEIVER_RESET_ATTR_ID(6),
+	TRANSCEIVER_RESET_ATTR_ID(7),
+	TRANSCEIVER_RESET_ATTR_ID(8),
+	TRANSCEIVER_RESET_ATTR_ID(9),
+	TRANSCEIVER_RESET_ATTR_ID(10),
+	TRANSCEIVER_RESET_ATTR_ID(11),
+	TRANSCEIVER_RESET_ATTR_ID(12),
+	TRANSCEIVER_RESET_ATTR_ID(13),
+	TRANSCEIVER_RESET_ATTR_ID(14),
+	TRANSCEIVER_RESET_ATTR_ID(15),
+	TRANSCEIVER_RESET_ATTR_ID(16),
+	TRANSCEIVER_RESET_ATTR_ID(17),
+	TRANSCEIVER_RESET_ATTR_ID(18),
+	TRANSCEIVER_RESET_ATTR_ID(19),
+	TRANSCEIVER_RESET_ATTR_ID(20),
+	TRANSCEIVER_RESET_ATTR_ID(21),
+	TRANSCEIVER_RESET_ATTR_ID(22),
+	TRANSCEIVER_RESET_ATTR_ID(23),
+	TRANSCEIVER_RESET_ATTR_ID(24),
+	TRANSCEIVER_RESET_ATTR_ID(25),
+	TRANSCEIVER_RESET_ATTR_ID(26),
+	TRANSCEIVER_RESET_ATTR_ID(27),
+	TRANSCEIVER_RESET_ATTR_ID(28),
+	TRANSCEIVER_RESET_ATTR_ID(29),
+	TRANSCEIVER_RESET_ATTR_ID(30),
+	TRANSCEIVER_RESET_ATTR_ID(31),
+	TRANSCEIVER_RESET_ATTR_ID(32),
+	TRANSCEIVER_RESET_ATTR_ID(33),
+	TRANSCEIVER_RESET_ATTR_ID(34),
+	TRANSCEIVER_RESET_ATTR_ID(35),
+	TRANSCEIVER_RESET_ATTR_ID(36),
+	TRANSCEIVER_RESET_ATTR_ID(37),
+	TRANSCEIVER_RESET_ATTR_ID(38),
+	TRANSCEIVER_RESET_ATTR_ID(39),
+	TRANSCEIVER_RESET_ATTR_ID(40),
+	TRANSCEIVER_RESET_ATTR_ID(41),
+	TRANSCEIVER_RESET_ATTR_ID(42),
+	TRANSCEIVER_RESET_ATTR_ID(43),
+	TRANSCEIVER_RESET_ATTR_ID(44),
+	TRANSCEIVER_RESET_ATTR_ID(45),
+	TRANSCEIVER_RESET_ATTR_ID(46),
+	TRANSCEIVER_RESET_ATTR_ID(47),
+	TRANSCEIVER_RESET_ATTR_ID(48),
+	TRANSCEIVER_RESET_ATTR_ID(49),
+	TRANSCEIVER_RESET_ATTR_ID(50),
+	TRANSCEIVER_RESET_ATTR_ID(51),
+	TRANSCEIVER_RESET_ATTR_ID(52),
+	TRANSCEIVER_RESET_ATTR_ID(53),
+	TRANSCEIVER_RESET_ATTR_ID(54),
+	TRANSCEIVER_RESET_ATTR_ID(55),
+	TRANSCEIVER_RESET_ATTR_ID(56),
+	TRANSCEIVER_RESET_ATTR_ID(57),
+	TRANSCEIVER_RESET_ATTR_ID(58),
+	TRANSCEIVER_RESET_ATTR_ID(59),
+	TRANSCEIVER_RESET_ATTR_ID(60),
+	TRANSCEIVER_RESET_ATTR_ID(61),
+	TRANSCEIVER_RESET_ATTR_ID(62),
+	TRANSCEIVER_RESET_ATTR_ID(63),
+	TRANSCEIVER_RESET_ATTR_ID(64),
+	TRANSCEIVER_LPMODE_ATTR_ID(1),
+	TRANSCEIVER_LPMODE_ATTR_ID(2),
+	TRANSCEIVER_LPMODE_ATTR_ID(3),
+	TRANSCEIVER_LPMODE_ATTR_ID(4),
+	TRANSCEIVER_LPMODE_ATTR_ID(5),
+	TRANSCEIVER_LPMODE_ATTR_ID(6),
+	TRANSCEIVER_LPMODE_ATTR_ID(7),
+	TRANSCEIVER_LPMODE_ATTR_ID(8),
+	TRANSCEIVER_LPMODE_ATTR_ID(9),
+	TRANSCEIVER_LPMODE_ATTR_ID(10),
+	TRANSCEIVER_LPMODE_ATTR_ID(11),
+	TRANSCEIVER_LPMODE_ATTR_ID(12),
+	TRANSCEIVER_LPMODE_ATTR_ID(13),
+	TRANSCEIVER_LPMODE_ATTR_ID(14),
+	TRANSCEIVER_LPMODE_ATTR_ID(15),
+	TRANSCEIVER_LPMODE_ATTR_ID(16),
+	TRANSCEIVER_LPMODE_ATTR_ID(17),
+	TRANSCEIVER_LPMODE_ATTR_ID(18),
+	TRANSCEIVER_LPMODE_ATTR_ID(19),
+	TRANSCEIVER_LPMODE_ATTR_ID(20),
+	TRANSCEIVER_LPMODE_ATTR_ID(21),
+	TRANSCEIVER_LPMODE_ATTR_ID(22),
+	TRANSCEIVER_LPMODE_ATTR_ID(23),
+	TRANSCEIVER_LPMODE_ATTR_ID(24),
+	TRANSCEIVER_LPMODE_ATTR_ID(25),
+	TRANSCEIVER_LPMODE_ATTR_ID(26),
+	TRANSCEIVER_LPMODE_ATTR_ID(27),
+	TRANSCEIVER_LPMODE_ATTR_ID(28),
+	TRANSCEIVER_LPMODE_ATTR_ID(29),
+	TRANSCEIVER_LPMODE_ATTR_ID(30),
+	TRANSCEIVER_LPMODE_ATTR_ID(31),
+	TRANSCEIVER_LPMODE_ATTR_ID(32),
+	TRANSCEIVER_LPMODE_ATTR_ID(33),
+	TRANSCEIVER_LPMODE_ATTR_ID(34),
+	TRANSCEIVER_LPMODE_ATTR_ID(35),
+	TRANSCEIVER_LPMODE_ATTR_ID(36),
+	TRANSCEIVER_LPMODE_ATTR_ID(37),
+	TRANSCEIVER_LPMODE_ATTR_ID(38),
+	TRANSCEIVER_LPMODE_ATTR_ID(39),
+	TRANSCEIVER_LPMODE_ATTR_ID(40),
+	TRANSCEIVER_LPMODE_ATTR_ID(41),
+	TRANSCEIVER_LPMODE_ATTR_ID(42),
+	TRANSCEIVER_LPMODE_ATTR_ID(43),
+	TRANSCEIVER_LPMODE_ATTR_ID(44),
+	TRANSCEIVER_LPMODE_ATTR_ID(45),
+	TRANSCEIVER_LPMODE_ATTR_ID(46),
+	TRANSCEIVER_LPMODE_ATTR_ID(47),
+	TRANSCEIVER_LPMODE_ATTR_ID(48),
+	TRANSCEIVER_LPMODE_ATTR_ID(49),
+	TRANSCEIVER_LPMODE_ATTR_ID(50),
+	TRANSCEIVER_LPMODE_ATTR_ID(51),
+	TRANSCEIVER_LPMODE_ATTR_ID(52),
+	TRANSCEIVER_LPMODE_ATTR_ID(53),
+	TRANSCEIVER_LPMODE_ATTR_ID(54),
+	TRANSCEIVER_LPMODE_ATTR_ID(55),
+	TRANSCEIVER_LPMODE_ATTR_ID(56),
+	TRANSCEIVER_LPMODE_ATTR_ID(57),
+	TRANSCEIVER_LPMODE_ATTR_ID(58),
+	TRANSCEIVER_LPMODE_ATTR_ID(59),
+	TRANSCEIVER_LPMODE_ATTR_ID(60),
+	TRANSCEIVER_LPMODE_ATTR_ID(61),
+	TRANSCEIVER_LPMODE_ATTR_ID(62),
+	TRANSCEIVER_LPMODE_ATTR_ID(63),
+	TRANSCEIVER_LPMODE_ATTR_ID(64),
+	TRANSCEIVER_TX_DISABLE_ATTR_ID(65),
+	TRANSCEIVER_TX_DISABLE_ATTR_ID(66),
+	TRANSCEIVER_TX_FAULT_ATTR_ID(65),
+	TRANSCEIVER_TX_FAULT_ATTR_ID(66),
+	TRANSCEIVER_RX_LOS_ATTR_ID(65),
+	TRANSCEIVER_RX_LOS_ATTR_ID(66),
+	PCIE_FPGA_UDB_VERSION,
+	PCIE_FPGA_LDB_VERSION,
+	PCIE_FPGA_SMB_VERSION,
+};
+
+enum pcie_type_e {
+	PCIE_FPGA_TYPE_UDB = 0,
+	PCIE_FPGA_TYPE_LDB
+};
+
+enum eeprom_page_type_e {
+	EEPROM_LOWER_PAGE = -1,
+	EEPROM_UPPER_PAGE
+};
+
+enum port_sysfs_attributes {
+	PORT_SYSFS_NAME_ID = 1,
+	PORT_SYSFS_PORT_NAME_ID,
+	PORT_SYSFS_DEV_CLASS_ID
+};
+
+/***********************************************
+ *       function declare
+ * *********************************************/
+static ssize_t port_status_read(struct device *dev,
+				struct device_attribute *da, char *buf);
+
+static ssize_t port_status_write(struct device *dev,
+				struct device_attribute *da, 
+				const char *buf, size_t count);
+
+static ssize_t port_read(struct device *dev, struct device_attribute *da,
+             char *buf);
+static ssize_t port_write(struct device *dev, struct device_attribute *da,
+            const char *buf, size_t count);
+
+static int fpga_i2c_ready_to_read(struct bin_attribute *attr, int page_type, 
+					int i2c_slave_addr);
+
+static ssize_t show_qsfp_reset(struct device *dev, 
+                struct device_attribute *devattr, char *buf);
+
+static ssize_t set_qsfp_reset(struct device *dev, 
+                struct device_attribute *devattr, const char *buf, size_t count);
+
+static ssize_t show_fp_led(struct device *dev, 
+                struct device_attribute *devattr, char *buf);
+
+static ssize_t set_fp_led(struct device *dev, 
+                struct device_attribute *devattr, const char *buf, size_t count);
+
+static ssize_t show_cpld_version(struct device *dev, 
+                struct device_attribute *devattr, char *buf);
+
+static ssize_t show_present_all(struct device *dev, 
+                struct device_attribute *devattr, char *buf);
+
+static ssize_t show_present(struct device *dev, struct device_attribute *devattr, char *buf);
+static ssize_t show_lpmode(struct device *dev, struct device_attribute *devattr, char *buf);
+static ssize_t set_lpmode(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count);
+static ssize_t show_reset(struct device *dev, struct device_attribute *devattr, char *buf);
+static ssize_t set_reset(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count);
+/* UDB */
+/*init eeprom private data*/
+static struct eeprom_bin_private_data pcie_udb_eeprom_bin_private_data[] = {
+	eeprom_udb_private_data_port_init(1),
+	eeprom_udb_private_data_port_init(2),
+	eeprom_udb_private_data_port_init(3),
+	eeprom_udb_private_data_port_init(4),
+	eeprom_udb_private_data_port_init(5),
+	eeprom_udb_private_data_port_init(6),
+	eeprom_udb_private_data_port_init(7),
+	eeprom_udb_private_data_port_init(8),
+	eeprom_udb_private_data_port_init(9),
+	eeprom_udb_private_data_port_init(10),
+	eeprom_udb_private_data_port_init(11),
+	eeprom_udb_private_data_port_init(12),
+	eeprom_udb_private_data_port_init(13),
+	eeprom_udb_private_data_port_init(14),
+	eeprom_udb_private_data_port_init(15),
+	eeprom_udb_private_data_port_init(16),
+	eeprom_udb_private_data_port_init(17),
+	eeprom_udb_private_data_port_init(18),
+	eeprom_udb_private_data_port_init(19),
+	eeprom_udb_private_data_port_init(20),
+	eeprom_udb_private_data_port_init(21),
+	eeprom_udb_private_data_port_init(22),
+	eeprom_udb_private_data_port_init(23),
+	eeprom_udb_private_data_port_init(24),
+	eeprom_udb_private_data_port_init(25),
+	eeprom_udb_private_data_port_init(26),
+	eeprom_udb_private_data_port_init(27),
+	eeprom_udb_private_data_port_init(28),
+	eeprom_udb_private_data_port_init(29),
+	eeprom_udb_private_data_port_init(30),
+	eeprom_udb_private_data_port_init(31),
+	eeprom_udb_private_data_port_init(32),
+};
+
+/*init device platform data*/
+static struct pcie_fpga_dev_platform_data pcie_udb_dev_platform_data[] = {
+	pcie_udb_qsfp_platform_data_init(1),
+	pcie_udb_qsfp_platform_data_init(2),
+	pcie_udb_qsfp_platform_data_init(3),
+	pcie_udb_qsfp_platform_data_init(4),
+	pcie_udb_qsfp_platform_data_init(5),
+	pcie_udb_qsfp_platform_data_init(6),
+	pcie_udb_qsfp_platform_data_init(7),
+	pcie_udb_qsfp_platform_data_init(8),
+	pcie_udb_qsfp_platform_data_init(9),
+	pcie_udb_qsfp_platform_data_init(10),
+	pcie_udb_qsfp_platform_data_init(11),
+	pcie_udb_qsfp_platform_data_init(12),
+	pcie_udb_qsfp_platform_data_init(13),
+	pcie_udb_qsfp_platform_data_init(14),
+	pcie_udb_qsfp_platform_data_init(15),
+	pcie_udb_qsfp_platform_data_init(16),
+	pcie_udb_qsfp_platform_data_init(17),
+	pcie_udb_qsfp_platform_data_init(18),
+	pcie_udb_qsfp_platform_data_init(19),
+	pcie_udb_qsfp_platform_data_init(20),
+	pcie_udb_qsfp_platform_data_init(21),
+	pcie_udb_qsfp_platform_data_init(22),
+	pcie_udb_qsfp_platform_data_init(23),
+	pcie_udb_qsfp_platform_data_init(24),
+	pcie_udb_qsfp_platform_data_init(25),
+	pcie_udb_qsfp_platform_data_init(26),
+	pcie_udb_qsfp_platform_data_init(27),
+	pcie_udb_qsfp_platform_data_init(28),
+	pcie_udb_qsfp_platform_data_init(29),
+	pcie_udb_qsfp_platform_data_init(30),
+	pcie_udb_qsfp_platform_data_init(31),
+	pcie_udb_qsfp_platform_data_init(32),
+};
+
+/* LDB */
+/*init eeprom private data*/
+static struct eeprom_bin_private_data pcie_ldb_eeprom_bin_private_data[] = {
+	eeprom_ldb_private_data_port_init(1),
+	eeprom_ldb_private_data_port_init(2),
+	eeprom_ldb_private_data_port_init(3),
+	eeprom_ldb_private_data_port_init(4),
+	eeprom_ldb_private_data_port_init(5),
+	eeprom_ldb_private_data_port_init(6),
+	eeprom_ldb_private_data_port_init(7),
+	eeprom_ldb_private_data_port_init(8),
+	eeprom_ldb_private_data_port_init(9),
+	eeprom_ldb_private_data_port_init(10),
+	eeprom_ldb_private_data_port_init(11),
+	eeprom_ldb_private_data_port_init(12),
+	eeprom_ldb_private_data_port_init(13),
+	eeprom_ldb_private_data_port_init(14),
+	eeprom_ldb_private_data_port_init(15),
+	eeprom_ldb_private_data_port_init(16),
+	eeprom_ldb_private_data_port_init(17),
+	eeprom_ldb_private_data_port_init(18),
+	eeprom_ldb_private_data_port_init(19),
+	eeprom_ldb_private_data_port_init(20),
+	eeprom_ldb_private_data_port_init(21),
+	eeprom_ldb_private_data_port_init(22),
+	eeprom_ldb_private_data_port_init(23),
+	eeprom_ldb_private_data_port_init(24),
+	eeprom_ldb_private_data_port_init(25),
+	eeprom_ldb_private_data_port_init(26),
+	eeprom_ldb_private_data_port_init(27),
+	eeprom_ldb_private_data_port_init(28),
+	eeprom_ldb_private_data_port_init(29),
+	eeprom_ldb_private_data_port_init(30),
+	eeprom_ldb_private_data_port_init(31),
+	eeprom_ldb_private_data_port_init(32),
+	eeprom_ldb_private_data_port_init(33), /*sfp: port65*/
+	eeprom_ldb_private_data_port_init(34), /*sfp: port66*/
+};
+
+/*init device platform data*/
+static struct pcie_fpga_dev_platform_data pcie_ldb_dev_platform_data[] = {
+	pcie_ldb_qsfp_platform_data_init(1),
+	pcie_ldb_qsfp_platform_data_init(2),
+	pcie_ldb_qsfp_platform_data_init(3),
+	pcie_ldb_qsfp_platform_data_init(4),
+	pcie_ldb_qsfp_platform_data_init(5),
+	pcie_ldb_qsfp_platform_data_init(6),
+	pcie_ldb_qsfp_platform_data_init(7),
+	pcie_ldb_qsfp_platform_data_init(8),
+	pcie_ldb_qsfp_platform_data_init(9),
+	pcie_ldb_qsfp_platform_data_init(10),
+	pcie_ldb_qsfp_platform_data_init(11),
+	pcie_ldb_qsfp_platform_data_init(12),
+	pcie_ldb_qsfp_platform_data_init(13),
+	pcie_ldb_qsfp_platform_data_init(14),
+	pcie_ldb_qsfp_platform_data_init(15),
+	pcie_ldb_qsfp_platform_data_init(16),
+	pcie_ldb_qsfp_platform_data_init(17),
+	pcie_ldb_qsfp_platform_data_init(18),
+	pcie_ldb_qsfp_platform_data_init(19),
+	pcie_ldb_qsfp_platform_data_init(20),
+	pcie_ldb_qsfp_platform_data_init(21),
+	pcie_ldb_qsfp_platform_data_init(22),
+	pcie_ldb_qsfp_platform_data_init(23),
+	pcie_ldb_qsfp_platform_data_init(24),
+	pcie_ldb_qsfp_platform_data_init(25),
+	pcie_ldb_qsfp_platform_data_init(26),
+	pcie_ldb_qsfp_platform_data_init(27),
+	pcie_ldb_qsfp_platform_data_init(28),
+	pcie_ldb_qsfp_platform_data_init(29),
+	pcie_ldb_qsfp_platform_data_init(30),
+	pcie_ldb_qsfp_platform_data_init(31),
+	pcie_ldb_qsfp_platform_data_init(32),
+	pcie_ldb_sfp_platform_data_init(33),  /*sfp: port65*/
+	pcie_ldb_sfp_platform_data_init(34),  /*sfp: port66*/
+};
+
+static void device_release(struct device *dev)
+{
+	return;
+}
+
+/*UDB platform device*/
+static struct platform_device pcie_udb_qsfp_device[] = {
+	pcie_udb_qsfp_device_port(0),
+	pcie_udb_qsfp_device_port(1),
+	pcie_udb_qsfp_device_port(2),
+	pcie_udb_qsfp_device_port(3),
+	pcie_udb_qsfp_device_port(4),
+	pcie_udb_qsfp_device_port(5),
+	pcie_udb_qsfp_device_port(6),
+	pcie_udb_qsfp_device_port(7),
+	pcie_udb_qsfp_device_port(8),
+	pcie_udb_qsfp_device_port(9),
+	pcie_udb_qsfp_device_port(10),
+	pcie_udb_qsfp_device_port(11),
+	pcie_udb_qsfp_device_port(12),
+	pcie_udb_qsfp_device_port(13),
+	pcie_udb_qsfp_device_port(14),
+	pcie_udb_qsfp_device_port(15),
+	pcie_udb_qsfp_device_port(16),
+	pcie_udb_qsfp_device_port(17),
+	pcie_udb_qsfp_device_port(18),
+	pcie_udb_qsfp_device_port(19),
+	pcie_udb_qsfp_device_port(20),
+	pcie_udb_qsfp_device_port(21),
+	pcie_udb_qsfp_device_port(22),
+	pcie_udb_qsfp_device_port(23),
+	pcie_udb_qsfp_device_port(24),
+	pcie_udb_qsfp_device_port(25),
+	pcie_udb_qsfp_device_port(26),
+	pcie_udb_qsfp_device_port(27),
+	pcie_udb_qsfp_device_port(28),
+	pcie_udb_qsfp_device_port(29),
+	pcie_udb_qsfp_device_port(30),
+	pcie_udb_qsfp_device_port(31),
+};
+
+/*LDB platform device*/
+static struct platform_device pcie_ldb_qsfp_device[] = {
+	pcie_ldb_qsfp_device_port(0),
+	pcie_ldb_qsfp_device_port(1),
+	pcie_ldb_qsfp_device_port(2),
+	pcie_ldb_qsfp_device_port(3),
+	pcie_ldb_qsfp_device_port(4),
+	pcie_ldb_qsfp_device_port(5),
+	pcie_ldb_qsfp_device_port(6),
+	pcie_ldb_qsfp_device_port(7),
+	pcie_ldb_qsfp_device_port(8),
+	pcie_ldb_qsfp_device_port(9),
+	pcie_ldb_qsfp_device_port(10),
+	pcie_ldb_qsfp_device_port(11),
+	pcie_ldb_qsfp_device_port(12),
+	pcie_ldb_qsfp_device_port(13),
+	pcie_ldb_qsfp_device_port(14),
+	pcie_ldb_qsfp_device_port(15),
+	pcie_ldb_qsfp_device_port(16),
+	pcie_ldb_qsfp_device_port(17),
+	pcie_ldb_qsfp_device_port(18),
+	pcie_ldb_qsfp_device_port(19),
+	pcie_ldb_qsfp_device_port(20),
+	pcie_ldb_qsfp_device_port(21),
+	pcie_ldb_qsfp_device_port(22),
+	pcie_ldb_qsfp_device_port(23),
+	pcie_ldb_qsfp_device_port(24),
+	pcie_ldb_qsfp_device_port(25),
+	pcie_ldb_qsfp_device_port(26),
+	pcie_ldb_qsfp_device_port(27),
+	pcie_ldb_qsfp_device_port(28),
+	pcie_ldb_qsfp_device_port(29),
+	pcie_ldb_qsfp_device_port(30),
+	pcie_ldb_qsfp_device_port(31),
+	pcie_ldb_sfp_device_port(32), /*sfp port65*/
+	pcie_ldb_sfp_device_port(33), /*sfp port66*/
+};
+
+#define DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(index) \
+	static SENSOR_DEVICE_ATTR(module_present_##index, S_IRUGO, show_present, NULL, MODULE_PRESENT_##index); \
+	static SENSOR_DEVICE_ATTR(module_reset_##index, S_IWUSR|S_IRUGO, show_reset, set_reset, MODULE_RESET_##index); \
+	static SENSOR_DEVICE_ATTR(module_lp_mode_##index, S_IRUGO | S_IWUSR, show_lpmode, set_lpmode, MODULE_LPMODE_##index)
+#define DECLARE_TRANSCEIVER_ATTR(index) \
+	&sensor_dev_attr_module_present_##index.dev_attr.attr, \
+	&sensor_dev_attr_module_reset_##index.dev_attr.attr, \
+	&sensor_dev_attr_module_lp_mode_##index.dev_attr.attr
+
+static SENSOR_DEVICE_ATTR(module_present_all, S_IRUGO, show_present_all, \
+			  NULL, MODULE_PRESENT_ALL);
+static SENSOR_DEVICE_ATTR(module_rx_los_all, S_IRUGO, port_status_read, NULL, \
+			  MODULE_RXLOS_ALL);
+
+/* transceiver attributes */
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(1);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(2);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(3);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(4);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(5);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(6);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(7);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(8);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(9);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(10);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(11);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(12);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(13);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(14);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(15);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(16);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(17);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(18);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(19);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(20);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(21);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(22);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(23);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(24);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(25);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(26);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(27);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(28);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(29);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(30);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(31);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(32);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(33);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(34);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(35);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(36);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(37);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(38);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(39);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(40);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(41);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(42);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(43);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(44);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(45);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(46);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(47);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(48);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(49);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(50);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(51);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(52);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(53);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(54);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(55);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(56);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(57);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(58);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(59);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(60);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(61);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(62);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(63);
+DECLARE_TRANSCEIVER_SENSOR_DEVICE_ATTR(64);
+static SENSOR_DEVICE_ATTR(module_present_65, S_IRUGO, port_status_read, NULL, MODULE_PRESENT_65);
+static SENSOR_DEVICE_ATTR(module_present_66, S_IRUGO, port_status_read, NULL, MODULE_PRESENT_66);
+static SENSOR_DEVICE_ATTR(module_tx_disable_65, S_IRUGO | S_IWUSR, port_status_read, port_status_write, MODULE_TX_DISABLE_65);
+static SENSOR_DEVICE_ATTR(module_tx_disable_66, S_IRUGO | S_IWUSR, port_status_read, port_status_write, MODULE_TX_DISABLE_66);
+static SENSOR_DEVICE_ATTR(module_tx_fault_65, S_IRUGO, port_status_read, NULL, MODULE_TX_FAULT_65);
+static SENSOR_DEVICE_ATTR(module_tx_fault_66, S_IRUGO, port_status_read, NULL, MODULE_TX_FAULT_66);
+static SENSOR_DEVICE_ATTR(module_rx_los_65, S_IRUGO, port_status_read, NULL, MODULE_RX_LOS_65);
+static SENSOR_DEVICE_ATTR(module_rx_los_66, S_IRUGO, port_status_read, NULL, MODULE_RX_LOS_66);
+static SENSOR_DEVICE_ATTR(udb_version, S_IRUGO, port_status_read, NULL, PCIE_FPGA_UDB_VERSION);
+static SENSOR_DEVICE_ATTR(ldb_version, S_IRUGO, port_status_read, NULL, PCIE_FPGA_LDB_VERSION);
+static SENSOR_DEVICE_ATTR(smb_version, S_IRUGO, port_status_read, NULL, PCIE_FPGA_SMB_VERSION);
+
+static SENSOR_DEVICE_ATTR(qsfp1_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 0);
+static SENSOR_DEVICE_ATTR(qsfp2_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 1);
+static SENSOR_DEVICE_ATTR(qsfp3_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 2);
+static SENSOR_DEVICE_ATTR(qsfp4_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 3);
+static SENSOR_DEVICE_ATTR(qsfp5_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 4);
+static SENSOR_DEVICE_ATTR(qsfp6_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 5);
+static SENSOR_DEVICE_ATTR(qsfp7_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 6);
+static SENSOR_DEVICE_ATTR(qsfp8_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 7);
+static SENSOR_DEVICE_ATTR(qsfp9_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 8);
+static SENSOR_DEVICE_ATTR(qsfp10_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 9);
+static SENSOR_DEVICE_ATTR(qsfp11_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 10);
+static SENSOR_DEVICE_ATTR(qsfp12_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 11);
+static SENSOR_DEVICE_ATTR(qsfp13_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 12);
+static SENSOR_DEVICE_ATTR(qsfp14_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 13);
+static SENSOR_DEVICE_ATTR(qsfp15_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 14);
+static SENSOR_DEVICE_ATTR(qsfp16_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 15);
+static SENSOR_DEVICE_ATTR(qsfp17_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 16);
+static SENSOR_DEVICE_ATTR(qsfp18_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 17);
+static SENSOR_DEVICE_ATTR(qsfp19_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 18);
+static SENSOR_DEVICE_ATTR(qsfp20_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 19);
+static SENSOR_DEVICE_ATTR(qsfp21_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 20);
+static SENSOR_DEVICE_ATTR(qsfp22_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 21);
+static SENSOR_DEVICE_ATTR(qsfp23_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 22);
+static SENSOR_DEVICE_ATTR(qsfp24_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 23);
+static SENSOR_DEVICE_ATTR(qsfp25_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 24);
+static SENSOR_DEVICE_ATTR(qsfp26_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 25);
+static SENSOR_DEVICE_ATTR(qsfp27_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 26);
+static SENSOR_DEVICE_ATTR(qsfp28_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 27);
+static SENSOR_DEVICE_ATTR(qsfp29_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 28);
+static SENSOR_DEVICE_ATTR(qsfp30_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 29);
+static SENSOR_DEVICE_ATTR(qsfp31_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 30);
+static SENSOR_DEVICE_ATTR(qsfp32_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 31);
+static SENSOR_DEVICE_ATTR(qsfp33_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 32);
+static SENSOR_DEVICE_ATTR(qsfp34_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 33);
+static SENSOR_DEVICE_ATTR(qsfp35_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 34);
+static SENSOR_DEVICE_ATTR(qsfp36_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 35);
+static SENSOR_DEVICE_ATTR(qsfp37_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 36);
+static SENSOR_DEVICE_ATTR(qsfp38_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 37);
+static SENSOR_DEVICE_ATTR(qsfp39_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 38);
+static SENSOR_DEVICE_ATTR(qsfp40_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 39);
+static SENSOR_DEVICE_ATTR(qsfp41_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 40);
+static SENSOR_DEVICE_ATTR(qsfp42_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 41);
+static SENSOR_DEVICE_ATTR(qsfp43_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 42);
+static SENSOR_DEVICE_ATTR(qsfp44_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 43);
+static SENSOR_DEVICE_ATTR(qsfp45_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 44);
+static SENSOR_DEVICE_ATTR(qsfp46_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 45);
+static SENSOR_DEVICE_ATTR(qsfp47_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 46);
+static SENSOR_DEVICE_ATTR(qsfp48_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 47);
+static SENSOR_DEVICE_ATTR(qsfp49_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 48);
+static SENSOR_DEVICE_ATTR(qsfp50_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 49);
+static SENSOR_DEVICE_ATTR(qsfp51_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 50);
+static SENSOR_DEVICE_ATTR(qsfp52_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 51);
+static SENSOR_DEVICE_ATTR(qsfp53_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 52);
+static SENSOR_DEVICE_ATTR(qsfp54_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 53);
+static SENSOR_DEVICE_ATTR(qsfp55_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 54);
+static SENSOR_DEVICE_ATTR(qsfp56_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 55);
+static SENSOR_DEVICE_ATTR(qsfp57_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 56);
+static SENSOR_DEVICE_ATTR(qsfp58_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 57);
+static SENSOR_DEVICE_ATTR(qsfp59_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 58);
+static SENSOR_DEVICE_ATTR(qsfp60_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 59);
+static SENSOR_DEVICE_ATTR(qsfp61_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 60);
+static SENSOR_DEVICE_ATTR(qsfp62_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 61);
+static SENSOR_DEVICE_ATTR(qsfp63_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 62);
+static SENSOR_DEVICE_ATTR(qsfp64_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 63);
+
+static SENSOR_DEVICE_ATTR(led_sys, S_IRUGO | S_IWUSR, show_fp_led, set_fp_led, 0);
+static SENSOR_DEVICE_ATTR(udb_cpld1_ver, S_IRUGO, show_cpld_version, NULL, 0);
+static SENSOR_DEVICE_ATTR(udb_cpld2_ver, S_IRUGO, show_cpld_version, NULL, 1);
+static SENSOR_DEVICE_ATTR(ldb_cpld1_ver, S_IRUGO, show_cpld_version, NULL, 2);
+static SENSOR_DEVICE_ATTR(ldb_cpld2_ver, S_IRUGO, show_cpld_version, NULL, 3);
+
+static struct attribute *fpga_transceiver_attributes[] = {
+	&sensor_dev_attr_module_present_all.dev_attr.attr,
+	&sensor_dev_attr_module_rx_los_all.dev_attr.attr,
+	DECLARE_TRANSCEIVER_ATTR(1),
+	DECLARE_TRANSCEIVER_ATTR(2),
+	DECLARE_TRANSCEIVER_ATTR(3),
+	DECLARE_TRANSCEIVER_ATTR(4),
+	DECLARE_TRANSCEIVER_ATTR(5),
+	DECLARE_TRANSCEIVER_ATTR(6),
+	DECLARE_TRANSCEIVER_ATTR(7),
+	DECLARE_TRANSCEIVER_ATTR(8),
+	DECLARE_TRANSCEIVER_ATTR(9),
+	DECLARE_TRANSCEIVER_ATTR(10),
+	DECLARE_TRANSCEIVER_ATTR(11),
+	DECLARE_TRANSCEIVER_ATTR(12),
+	DECLARE_TRANSCEIVER_ATTR(13),
+	DECLARE_TRANSCEIVER_ATTR(14),
+	DECLARE_TRANSCEIVER_ATTR(15),
+	DECLARE_TRANSCEIVER_ATTR(16),
+	DECLARE_TRANSCEIVER_ATTR(17),
+	DECLARE_TRANSCEIVER_ATTR(18),
+	DECLARE_TRANSCEIVER_ATTR(19),
+	DECLARE_TRANSCEIVER_ATTR(20),
+	DECLARE_TRANSCEIVER_ATTR(21),
+	DECLARE_TRANSCEIVER_ATTR(22),
+	DECLARE_TRANSCEIVER_ATTR(23),
+	DECLARE_TRANSCEIVER_ATTR(24),
+	DECLARE_TRANSCEIVER_ATTR(25),
+	DECLARE_TRANSCEIVER_ATTR(26),
+	DECLARE_TRANSCEIVER_ATTR(27),
+	DECLARE_TRANSCEIVER_ATTR(28),
+	DECLARE_TRANSCEIVER_ATTR(29),
+	DECLARE_TRANSCEIVER_ATTR(30),
+	DECLARE_TRANSCEIVER_ATTR(31),
+	DECLARE_TRANSCEIVER_ATTR(32),
+	DECLARE_TRANSCEIVER_ATTR(33),
+	DECLARE_TRANSCEIVER_ATTR(34),
+	DECLARE_TRANSCEIVER_ATTR(35),
+	DECLARE_TRANSCEIVER_ATTR(36),
+	DECLARE_TRANSCEIVER_ATTR(37),
+	DECLARE_TRANSCEIVER_ATTR(38),
+	DECLARE_TRANSCEIVER_ATTR(39),
+	DECLARE_TRANSCEIVER_ATTR(40),
+	DECLARE_TRANSCEIVER_ATTR(41),
+	DECLARE_TRANSCEIVER_ATTR(42),
+	DECLARE_TRANSCEIVER_ATTR(43),
+	DECLARE_TRANSCEIVER_ATTR(44),
+	DECLARE_TRANSCEIVER_ATTR(45),
+	DECLARE_TRANSCEIVER_ATTR(46),
+	DECLARE_TRANSCEIVER_ATTR(47),
+	DECLARE_TRANSCEIVER_ATTR(48),
+	DECLARE_TRANSCEIVER_ATTR(49),
+	DECLARE_TRANSCEIVER_ATTR(50),
+	DECLARE_TRANSCEIVER_ATTR(51),
+	DECLARE_TRANSCEIVER_ATTR(52),
+	DECLARE_TRANSCEIVER_ATTR(53),
+	DECLARE_TRANSCEIVER_ATTR(54),
+	DECLARE_TRANSCEIVER_ATTR(55),
+	DECLARE_TRANSCEIVER_ATTR(56),
+	DECLARE_TRANSCEIVER_ATTR(57),
+	DECLARE_TRANSCEIVER_ATTR(58),
+	DECLARE_TRANSCEIVER_ATTR(59),
+	DECLARE_TRANSCEIVER_ATTR(60),
+	DECLARE_TRANSCEIVER_ATTR(61),
+	DECLARE_TRANSCEIVER_ATTR(62),
+	DECLARE_TRANSCEIVER_ATTR(63),
+	DECLARE_TRANSCEIVER_ATTR(64),
+	&sensor_dev_attr_module_present_65.dev_attr.attr,
+	&sensor_dev_attr_module_present_66.dev_attr.attr,
+	&sensor_dev_attr_module_tx_disable_65.dev_attr.attr,
+	&sensor_dev_attr_module_tx_disable_66.dev_attr.attr,
+	&sensor_dev_attr_module_tx_fault_65.dev_attr.attr,
+	&sensor_dev_attr_module_tx_fault_66.dev_attr.attr,
+	&sensor_dev_attr_module_rx_los_65.dev_attr.attr,
+	&sensor_dev_attr_module_rx_los_66.dev_attr.attr,
+	&sensor_dev_attr_udb_version.dev_attr.attr,
+	&sensor_dev_attr_ldb_version.dev_attr.attr,
+	&sensor_dev_attr_smb_version.dev_attr.attr,
+
+	&sensor_dev_attr_qsfp1_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_reset.dev_attr.attr,
+	&sensor_dev_attr_qsfp17_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_reset.dev_attr.attr,
+	&sensor_dev_attr_qsfp33_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp37_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp38_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp39_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp40_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp41_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp42_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp43_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp44_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp45_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp46_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp47_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp48_reset.dev_attr.attr,
+	&sensor_dev_attr_qsfp49_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp50_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp51_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp52_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp53_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp54_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp55_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp56_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp57_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp58_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp59_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp60_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp61_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp62_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp63_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp64_reset.dev_attr.attr,
+
+	&sensor_dev_attr_led_sys.dev_attr.attr,
+	&sensor_dev_attr_udb_cpld1_ver.dev_attr.attr,
+	&sensor_dev_attr_udb_cpld2_ver.dev_attr.attr,
+	&sensor_dev_attr_ldb_cpld1_ver.dev_attr.attr,
+	&sensor_dev_attr_ldb_cpld2_ver.dev_attr.attr,
+
+	NULL
+};
+
+/* eeprom attribute */
+
+/* optoe{1, 2, 3} */
+static SENSOR_DEVICE_ATTR(name, S_IRUGO, port_read, NULL, PORT_SYSFS_NAME_ID);
+
+  /* port{1~64} */
+static SENSOR_DEVICE_ATTR(port_name, S_IRUGO, port_read, NULL,
+			PORT_SYSFS_PORT_NAME_ID);
+
+/* 1 or 2 or 3 */
+static SENSOR_DEVICE_ATTR(dev_class, S_IRUGO|S_IWUSR, port_read, port_write,
+			PORT_SYSFS_DEV_CLASS_ID); 
+
+static struct attribute *fpga_eeprom_attributes[] = {
+	&sensor_dev_attr_name.dev_attr.attr,
+	&sensor_dev_attr_port_name.dev_attr.attr,
+	&sensor_dev_attr_dev_class.dev_attr.attr,
+	NULL
+};
+
+static const struct attribute_group fpga_port_stat_group = {
+	.attrs = fpga_transceiver_attributes,
+};
+
+static const struct attribute_group fpga_eeprom_group = {
+	.attrs = fpga_eeprom_attributes,
+};
+
+static char *show_date_time(void)
+{
+	struct timespec64 tv;
+	struct tm tm_val;
+
+	memset(g_datetime, 0, DATETIME_LEN);
+
+	ktime_get_real_ts64(&tv);
+	time64_to_tm(tv.tv_sec, 0, &tm_val);
+	sprintf(g_datetime, "[%04d/%02d/%02d-%02d:%02d:%02d.%06ld]",
+	1900 + tm_val.tm_year,
+	tm_val.tm_mon + 1,
+	tm_val.tm_mday,
+	tm_val.tm_hour,
+	tm_val.tm_min,
+	tm_val.tm_sec,
+	tv.tv_nsec/1000); /*usec*/
+
+	return g_datetime;
+}
+
+static ssize_t show_qsfp_reset(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+
+    return sprintf(buf, "%d\n", fpga_ctl->reset_list[sda->index]);
+}
+
+static ssize_t set_qsfp_reset(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 0xFF) {
+        return -EINVAL;
+    }
+
+    fpga_ctl->reset_list[sda->index] = usr_val;
+    return count;
+}
+
+static ssize_t show_fp_led(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u32 val = 0;
+	
+	val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + UDB_CPLD2_FP_LED_SYS2);
+	
+    return sprintf(buf, "%d\n", (val>>8)&0xF);
+}
+
+static ssize_t set_fp_led(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 usr_val8 = 0;
+	u32 usr_val = 0;
+	u32 reg_val = 0;
+
+    int ret = kstrtou8(buf, 10, &usr_val8);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val8 > 0xF) {
+        return -EINVAL;
+    }
+	
+	reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + UDB_CPLD2_FP_LED_SYS2);
+    reg_val = reg_val & 0xFFFFF0FF;
+    usr_val = usr_val8 << 8;
+    iowrite32((reg_val | usr_val), fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + UDB_CPLD2_FP_LED_SYS2);
+
+    return count;
+}
+
+static ssize_t show_cpld_version(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u8 major_ver = 0;
+	u8 minor_ver = 0;	
+	
+	switch (sda->index) {
+    case 0:
+        major_ver = (fpga_ctl->udb_cpld1_ver & 0xFF00) >> 8;
+		minor_ver = fpga_ctl->udb_cpld1_ver & 0xFF;
+		break;
+    case 1:
+        major_ver = (fpga_ctl->udb_cpld2_ver & 0xFF00) >> 8;
+		minor_ver = fpga_ctl->udb_cpld2_ver & 0xFF;
+        break;
+    case 2:
+        major_ver = (fpga_ctl->ldb_cpld1_ver & 0xFF00) >> 8;
+		minor_ver = fpga_ctl->ldb_cpld1_ver & 0xFF;
+        break;    
+    case 3:
+        major_ver = (fpga_ctl->ldb_cpld2_ver & 0xFF00) >> 8;
+		minor_ver = fpga_ctl->ldb_cpld2_ver & 0xFF;
+	default:        
+        break;
+    }
+
+    return sprintf(buf, "%d.%d\n", major_ver, minor_ver);
+}
+
+static ssize_t show_present_all(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u32 qsfp_present_udb = 0;
+	u32 qsfp_present_ldb = 0;
+	u32 sfp_present = 0;
+	u8 val_sfp = 0;
+
+	qsfp_present_udb = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_PRESENT_REG_OFFSET);
+	qsfp_present_ldb = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_PRESENT_REG_OFFSET);
+	sfp_present = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + 0x100C);
+
+	val_sfp = (sfp_present & 0x4) >> 2 |  (sfp_present & 0x400) >> 9;
+
+    return sprintf(buf, "0x%.1x%.8x%.8x\n", val_sfp, qsfp_present_ldb, qsfp_present_udb);
+}
+
+static ssize_t show_present(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u32 reg_val = 0;	
+	u8 bit_val = 0;
+
+	switch(sda->index) {
+	case MODULE_PRESENT_1 ... MODULE_PRESENT_32:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_PRESENT_REG_OFFSET);
+	    bit_val = (reg_val >> (sda->index - MODULE_PRESENT_1)) & 0x1;
+		break;
+	case MODULE_PRESENT_33 ... MODULE_PRESENT_64:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_PRESENT_REG_OFFSET);
+		bit_val = (reg_val >> (sda->index - MODULE_PRESENT_33)) & 0x1;
+		break;
+	case MODULE_PRESENT_65:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + 0x100C);
+		bit_val = (reg_val & 0x400) >> 9;
+		break;
+	case MODULE_PRESENT_66:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + 0x100C);
+		bit_val = (reg_val & 0x4) >> 2;
+		break;
+	default:
+		return -EINVAL;
+		break;
+	}
+
+	return sprintf(buf, "%d\n", bit_val);
+}
+
+static ssize_t show_lpmode(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u32 reg_val = 0;	
+	u8 bit_val = 0;
+
+	switch(sda->index) {
+	case MODULE_LPMODE_1 ... MODULE_LPMODE_32:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_LPMODE_REG_OFFSET);
+	    bit_val = (reg_val >> (sda->index - MODULE_LPMODE_1)) & 0x1;
+		break;
+	case MODULE_LPMODE_33 ... MODULE_LPMODE_64:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_LPMODE_REG_OFFSET);
+		bit_val = (reg_val >> (sda->index - MODULE_LPMODE_33)) & 0x1;
+		break;	
+	default:
+		return -EINVAL;
+		break;
+	}
+
+	return sprintf(buf, "%d\n", bit_val);
+}
+
+static ssize_t set_lpmode(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u32 reg_val = 0;
+	u32 mask = 0;
+	u8 usr_val = 0;
+	u32 usr_val32 = 0;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 0x1) {
+        return -EINVAL;
+    }
+
+	switch(sda->index) {
+	case MODULE_LPMODE_1 ... MODULE_LPMODE_32:
+	    mask = (~(1 << (sda->index - MODULE_LPMODE_1))) & 0xFFFFFFFF;
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_LPMODE_REG_OFFSET);
+		reg_val = reg_val & mask;
+		usr_val32 = usr_val << (sda->index - MODULE_LPMODE_1);
+		iowrite32((reg_val | usr_val32), fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_LPMODE_REG_OFFSET);
+		break;
+	case MODULE_LPMODE_33 ... MODULE_LPMODE_64:
+	    mask = (~(1 << (sda->index - MODULE_LPMODE_33))) & 0xFFFFFFFF;
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_LPMODE_REG_OFFSET);
+		reg_val = reg_val & mask;
+		usr_val32 = usr_val << (sda->index - MODULE_LPMODE_33);
+		iowrite32((reg_val | usr_val32), fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_LPMODE_REG_OFFSET);
+		break;	
+	default:
+		return -EINVAL;
+		break;
+	}
+
+	return count;
+}
+
+static ssize_t show_reset(struct device *dev, struct device_attribute *devattr, char *buf) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u32 reg_val = 0;	
+	u8 bit_val = 0;
+
+	switch(sda->index) {
+	case MODULE_RESET_1 ... MODULE_RESET_32:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_RESET_REG_OFFSET);
+	    bit_val = (reg_val >> (sda->index - MODULE_RESET_1)) & 0x1;
+		break;
+	case MODULE_RESET_33 ... MODULE_RESET_64:
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_RESET_REG_OFFSET);
+		bit_val = (reg_val >> (sda->index - MODULE_RESET_33)) & 0x1;
+		break;	
+	default:
+		return -EINVAL;
+		break;
+	}
+
+	return sprintf(buf, "%d\n", bit_val);
+}
+
+static ssize_t set_reset(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count) 
+{
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+	u32 reg_val = 0;
+	u32 mask = 0;
+	u8 usr_val = 0;
+	u32 usr_val32 = 0;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret; 
+    }
+    if (usr_val > 0x1) {
+        return -EINVAL;
+    }
+	
+	switch(sda->index) {
+	case MODULE_RESET_1 ... MODULE_RESET_32:
+	    mask = (~(1 << (sda->index - MODULE_RESET_1))) & 0xFFFFFFFF;
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_RESET_REG_OFFSET);
+		reg_val = reg_val & mask;
+		usr_val32 = usr_val << (sda->index - MODULE_RESET_1);
+		iowrite32((reg_val | usr_val32), fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + QSFP_RESET_REG_OFFSET);
+		break;
+	case MODULE_RESET_33 ... MODULE_RESET_64:
+	    mask = (~(1 << (sda->index - MODULE_RESET_33))) & 0xFFFFFFFF;
+	    reg_val = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_RESET_REG_OFFSET);
+		reg_val = reg_val & mask;
+		usr_val32 = usr_val << (sda->index - MODULE_RESET_33);
+		iowrite32((reg_val | usr_val32), fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + QSFP_RESET_REG_OFFSET);
+		break;	
+	default:
+		return -EINVAL;
+		break;
+	}
+
+	return count;
+}
+
+static ssize_t fpga_read_sfp_ddm_status_value(struct bin_attribute *eeprom)
+{
+	u32 reg_val = 0;
+	u16 pageable = 0;
+	u16 ddm_support = 0;
+	struct eeprom_bin_private_data *pdata = NULL;
+
+	if(eeprom == NULL)
+		return -1;
+
+	pdata = eeprom->private; /*assign private sturct value*/
+
+	if(pdata->port_num > FPGA_QSFP_PORT_NUM) {
+		/*get sfp pagable status*/
+		if( fpga_i2c_ready_to_read(eeprom, EEPROM_LOWER_PAGE, 
+					pdata->i2c_slave_addr) != 1)
+			return 0;
+
+		reg_val = ioread32(pdata->data_base_addr + 
+			  (pdata->i2c_rtc_read_data + TWO_ADDR_PAGEABLE_REG));
+		pageable = (reg_val) & 0xff;  /*check on bit4*/
+
+		/*get sfp support a2 status*/
+		if( fpga_i2c_ready_to_read(eeprom, EEPROM_LOWER_PAGE,
+						pdata->i2c_slave_addr) != 1)
+			return 0;
+
+		reg_val = ioread32(pdata->data_base_addr + 
+			  (pdata->i2c_rtc_read_data + TWO_ADDR_0X51_REG));
+		ddm_support = (reg_val) & 0xff;  /*check on bit6*/
+
+		pdata->pageable = (pageable & TWO_ADDR_PAGEABLE ) ? 1 : 0;
+		pdata->sfp_support_a2 = (ddm_support & TWO_ADDR_0X51_SUPP) 
+					? 1 : 0;
+	}
+
+	return 0;
+}
+
+static ssize_t fpga_read_port_status_value(struct bin_attribute *eeprom)
+{
+	int i = 0;
+
+	if(time_before(jiffies, fpga_ctl->last_updated + HZ / 2))
+		return 0;
+
+	for(i = 0; i < ARRAY_SIZE(fpga_ctl->pci_fpga_dev)-1; i++){
+		/*Update present*/
+		fpga_ctl->pci_fpga_dev[i].qsfp_present = 
+			ioread32(fpga_ctl->pci_fpga_dev[i].data_base_addr +
+				 QSFP_PRESENT_REG_OFFSET);
+
+		if(i==PCI_SUBSYSTEM_ID_LDB){
+			/*Read output data*/
+			fpga_ctl->pci_fpga_dev[i].sfp_output_data = 
+				ioread32(fpga_ctl->pci_fpga_dev[i].data_base_addr + 
+					 SFP_LDB_GPIO1_DATA_OUT);
+			/*Read input data*/
+			fpga_ctl->pci_fpga_dev[i].sfp_input_data = 
+				ioread32(fpga_ctl->pci_fpga_dev[i].data_base_addr + 
+					 SFP_LDB_GPIO1_DATA_IN);
+		}
+		/*Update lpmode*/
+		fpga_ctl->pci_fpga_dev[i].qsfp_lpmode = 
+				ioread32(fpga_ctl->pci_fpga_dev[i].data_base_addr + 
+					 QSFP_LPMODE_REG_OFFSET);
+		/*Update reset*/
+		fpga_ctl->pci_fpga_dev[i].qsfp_reset = 
+				ioread32(fpga_ctl->pci_fpga_dev[i].data_base_addr + 
+					 QSFP_RESET_REG_OFFSET);
+	}
+
+	fpga_ctl->last_updated = jiffies;
+
+	return 0;
+}
+
+static ssize_t fpga_write_port_value(int fpga_type, int set_type, int bit_num,
+					long val)
+{
+	long val_set = 0;
+	u32  reg_val = 0;
+
+	if(set_type == PCIE_FPGA_SET_LPMODE) {
+		reg_val = fpga_ctl->pci_fpga_dev[fpga_type].qsfp_lpmode;
+	} else if(set_type == PCIE_FPGA_SET_RESET) {
+		reg_val = fpga_ctl->pci_fpga_dev[fpga_type].qsfp_reset;
+	} else {
+		reg_val = fpga_ctl->pci_fpga_dev[fpga_type].sfp_output_data;
+	}
+
+	if(val){
+		val_set = reg_val | (1<<bit_num);
+	} else {
+		val_set = reg_val & ~(1<<bit_num);
+	}
+
+	switch(set_type){
+	case PCIE_FPGA_SET_LPMODE:
+		iowrite32(val_set, fpga_ctl->pci_fpga_dev[fpga_type].data_base_addr + 
+			  QSFP_LPMODE_REG_OFFSET);
+		break;
+	case PCIE_FPGA_SET_RESET:
+		iowrite32(val_set, fpga_ctl->pci_fpga_dev[fpga_type].data_base_addr + 
+			  QSFP_RESET_REG_OFFSET);
+		break;
+	case PCIE_FPGA_SET_TX_DISABLE:
+		iowrite32(val_set, fpga_ctl->pci_fpga_dev[fpga_type].data_base_addr + 
+			  SFP_LDB_GPIO1_DATA_OUT);
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static int get_present_by_attr_index(int attr_index)
+{
+	int present = 0;
+	int index_mapping = 0;
+
+	switch(attr_index) {
+	case MODULE_PRESENT_1 ... MODULE_PRESENT_32:
+	case MODULE_PRESENT_33 ... MODULE_PRESENT_64:
+	case MODULE_PRESENT_65: /*sfp port*/
+	case MODULE_PRESENT_66: /*sfp port*/
+		index_mapping = attr_index;
+		break;
+	case MODULE_LPMODE_1 ... MODULE_LPMODE_32:
+		index_mapping = attr_index - MODULE_LPMODE_1;
+		break;
+	case MODULE_LPMODE_33 ... MODULE_LPMODE_64:
+		index_mapping = attr_index - MODULE_LPMODE_33;
+		break;
+	case MODULE_RESET_1 ... MODULE_RESET_32:
+		index_mapping = attr_index - MODULE_RESET_1;
+		break;
+	case MODULE_RESET_33 ... MODULE_RESET_64:
+		index_mapping = attr_index - MODULE_RESET_33;
+		break; 
+	case MODULE_TX_DISABLE_65:
+	case MODULE_TX_FAULT_65:
+	case MODULE_RX_LOS_65:
+		index_mapping = MODULE_PRESENT_65;
+		break;
+	case MODULE_TX_DISABLE_66:
+	case MODULE_TX_FAULT_66:
+	case MODULE_RX_LOS_66:
+		index_mapping = MODULE_PRESENT_66;
+		break;
+	default:
+		index_mapping = -EINVAL;
+		break;
+	}
+
+	if((index_mapping >= MODULE_PRESENT_1) &&
+	   (index_mapping <= MODULE_PRESENT_32))
+		present =(
+		(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].qsfp_present>>
+		(index_mapping - MODULE_PRESENT_1)) & 0x1)?0:1;	
+	else if((index_mapping >= MODULE_PRESENT_33) &&
+		(index_mapping <= MODULE_PRESENT_64))
+		present = (
+		(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].qsfp_present>>
+		(index_mapping - MODULE_PRESENT_33)) & 0x1)?0:1;
+	else if(index_mapping == MODULE_PRESENT_65)
+		present = ((SFP_PORT0_ABS
+		(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data))
+		 & 0x1)?0:1;
+	else if(index_mapping == MODULE_PRESENT_66)
+		present = ((SFP_PORT1_ABS
+		(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data)) 
+		& 0x1)?0:1;
+	else
+		present = 0; /*unpresent*/
+
+	return present;
+}
+
+static ssize_t port_status_read(struct device *dev,
+				struct device_attribute *da, char *buf)
+{
+	int  present = 0;
+	ssize_t  ret = 0;
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct bin_attribute *eeprom = NULL;
+
+	mutex_lock(&update_lock);
+	fpga_read_port_status_value(eeprom);
+
+	present = get_present_by_attr_index(attr->index);
+
+	switch(attr->index) {
+	case MODULE_PRESENT_1 ... MODULE_PRESENT_32:
+	case MODULE_PRESENT_33 ... MODULE_PRESENT_64:
+	case MODULE_PRESENT_65: /*sfp port*/
+	case MODULE_PRESENT_66: /*sfp port*/
+		ret = sprintf(buf, "%d\n", (present & 0x1)? 0:1);
+		break;
+	case MODULE_PRESENT_ALL:
+		ret = sprintf(buf,
+			"0x%.1x%.8x%.8x\n",
+			~(get_present_by_attr_index(MODULE_PRESENT_65) |
+			get_present_by_attr_index(MODULE_PRESENT_66) << 1) & 0xF,
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].qsfp_present,
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].qsfp_present			
+			);
+		break;
+	case MODULE_LPMODE_1 ... MODULE_LPMODE_32:
+		ret = sprintf(buf, "%d\n", 
+			((fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].qsfp_lpmode >> 
+			 (attr->index - MODULE_LPMODE_1)) & 0x1));		
+		break;
+	case MODULE_LPMODE_33 ... MODULE_LPMODE_64:
+		ret = sprintf(buf, "%d\n", 
+				((fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].qsfp_lpmode >> 
+				(attr->index - MODULE_LPMODE_33)) & 0x1));		
+		break;
+	case MODULE_RESET_1 ... MODULE_RESET_32:
+		ret = sprintf(buf, "%d\n", 
+				((fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].qsfp_reset >>
+				(attr->index - MODULE_RESET_1)) & 0x1)? 1:0);
+		break;
+	case MODULE_RESET_33 ... MODULE_RESET_64:
+		ret = sprintf(buf, "%d\n", 
+		        ((fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].qsfp_reset >>
+				(attr->index - MODULE_RESET_33)) & 0x1)? 1:0);
+		break;
+	case MODULE_TX_DISABLE_65:
+		ret = sprintf(buf, "%d\n", (SFP_PORT0_TXDIS
+			      (fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data)) & 0x1);		
+		break;
+	case MODULE_TX_DISABLE_66:
+		ret = sprintf(buf, "%d\n", (SFP_PORT1_TXDIS
+				(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data)) & 0x1);		
+		break;
+	case MODULE_TX_FAULT_65:
+		ret = sprintf(buf, "%d\n", (SFP_PORT0_TXFLT(
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data)) & 0x1);		
+		break;
+	case MODULE_TX_FAULT_66:
+		ret = sprintf(buf, "%d\n", (SFP_PORT1_TXFLT(
+				fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data)) & 0x1);		
+		break;
+	case MODULE_RX_LOS_65:
+		ret = sprintf(buf, "%d\n", (SFP_PORT0_RXLOS(
+				fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data)) & 0x1);		
+		break;
+	case MODULE_RX_LOS_66:
+		ret = sprintf(buf, "%d\n", (SFP_PORT1_RXLOS(
+				fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data)) & 0x1);
+		break;
+	case MODULE_RXLOS_ALL:
+		ret = sprintf(buf,
+			"00 00 00 00 00 00 00 00 %.2x\n",
+			((SFP_PORT0_RXLOS(
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data))
+			& 0x1) << 1 |
+			((SFP_PORT1_RXLOS(
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data))
+			& 0x1)
+			);
+		break;
+	case PCIE_FPGA_UDB_VERSION:
+		ret = sprintf(buf, 
+			"%d.%d\n", 
+			(fpga_ctl->udb_version>>8) & 0x7f,
+			fpga_ctl->udb_version & 0xff);
+		break;
+	case PCIE_FPGA_LDB_VERSION:
+		ret = sprintf(buf, 
+			"%d.%d\n", 
+			(fpga_ctl->ldb_version>>8) & 0x7f, 
+			fpga_ctl->ldb_version & 0xff);
+		break;
+	case PCIE_FPGA_SMB_VERSION:
+		ret = sprintf(buf, 
+			"%d.%d\n", 
+			(fpga_ctl->smb_version>>8) & 0x7f, 
+			fpga_ctl->smb_version & 0xff);
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+	mutex_unlock(&update_lock);
+
+	return ret;
+}
+
+static ssize_t port_status_write(struct device *dev, struct device_attribute *da,
+            const char *buf, size_t count)
+{
+	long value;
+	int status;
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct bin_attribute *eeprom = NULL;
+
+	status = kstrtol(buf, 16, &value);
+	if (status)
+		return status;
+
+	mutex_lock(&update_lock);
+
+	switch(attr->index) {
+	case MODULE_LPMODE_1 ... MODULE_LPMODE_32:
+		fpga_write_port_value(PCIE_FPGA_UDB, PCIE_FPGA_SET_LPMODE, 
+					(attr->index - MODULE_LPMODE_1),
+					!!value);
+		break;
+	case MODULE_LPMODE_33 ... MODULE_LPMODE_64:
+		fpga_write_port_value(PCIE_FPGA_LDB, PCIE_FPGA_SET_LPMODE, 
+					(attr->index - MODULE_LPMODE_1), 
+					!!value);
+		break;
+	case MODULE_RESET_1 ... MODULE_RESET_32:
+		fpga_write_port_value(PCIE_FPGA_UDB, PCIE_FPGA_SET_RESET,
+					(attr->index - MODULE_RESET_1), 
+					!value);
+		break;
+	case MODULE_RESET_33 ... MODULE_RESET_64:
+		fpga_write_port_value(PCIE_FPGA_LDB, PCIE_FPGA_SET_RESET, 
+					(attr->index - MODULE_RESET_1), 
+					!value);
+		break;
+	case MODULE_TX_DISABLE_65 ... MODULE_TX_DISABLE_66:
+		fpga_write_port_value(PCIE_FPGA_LDB, PCIE_FPGA_SET_TX_DISABLE, 
+			((attr->index - MODULE_TX_DISABLE_65) 
+			? BIT(3) : BIT(11)), 
+			!!value); /*bit3 and bit11*/
+		break;
+	default:
+		mutex_unlock(&update_lock);
+		return  -EINVAL;
+	}
+
+	mutex_unlock(&update_lock);
+
+	return count;
+}
+
+static ssize_t port_read(struct device *dev, struct device_attribute *da, char *buf)
+{
+	ssize_t  ret = 0;
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct platform_device *pdev = to_platform_device(dev);
+	struct pcie_fpga_dev_platform_data *pdata = NULL;
+
+	pdata = pdev->dev.platform_data;
+
+	mutex_lock(&update_lock);
+	switch(attr->index) {
+	case PORT_SYSFS_PORT_NAME_ID:
+		ret = sprintf(buf, "%s\n", pdata->name);
+		break;
+	case PORT_SYSFS_NAME_ID:
+		ret = sprintf(buf, "%s\n", pdata->dev_name);
+		break;
+	case PORT_SYSFS_DEV_CLASS_ID:
+		ret = sprintf(buf, "%d\n", pdata->dev_class);
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+	mutex_unlock(&update_lock);
+
+	return ret;
+}
+
+static ssize_t port_write(struct device *dev, struct device_attribute *da,
+		const char *buf, size_t count)
+{
+	int value;
+	int status;
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct platform_device *pdev = to_platform_device(dev);
+	struct pcie_fpga_dev_platform_data *pdata = NULL;
+
+	pdata = pdev->dev.platform_data;
+
+	status = kstrtoint(buf, 10, &value);
+	if (status)
+		return status;
+
+	mutex_lock(&update_lock);
+	switch(attr->index) {
+	case PORT_SYSFS_DEV_CLASS_ID:
+		pdata->dev_class = value;
+		break;
+	default:
+		mutex_unlock(&update_lock);
+		return  -EINVAL;
+	}
+	mutex_unlock(&update_lock);
+	return count;
+}
+
+/*
+ * eeprom read function
+ */
+static int fpga_i2c_ready_to_read(struct bin_attribute *attr,
+				int page_type, int i2c_slave_addr)
+{
+	int  cnt = 0;
+	int  chk_state_cnt = 0;
+	u32  i2c_new_trigger_val = 0;
+	u32  flag = 0;
+	struct eeprom_bin_private_data *pdata = NULL;
+
+	pdata = attr->private;
+
+	/*Select i2c protocol profile*/
+	iowrite32(0x1, pdata->data_base_addr + pdata->i2c_mgmt_rtc0_profile);
+
+	/*clean read data*/
+	for(cnt = 0 ; cnt < 32; cnt++)
+		iowrite32(0x0, pdata->data_base_addr + 
+			 (pdata->i2c_rtc_read_data + (4 * cnt)));
+
+	/*clean done status*/
+	iowrite32(0x3, pdata->data_base_addr + pdata->i2c_contrl_rtc0_stats);
+
+	/*set read slave addr*/
+	iowrite32(0x10000080|(i2c_slave_addr << 8), pdata->data_base_addr + 
+		  pdata->i2c_contrl_rtc0_config_0);
+
+	/*triger*/
+	if(page_type == EEPROM_LOWER_PAGE)
+		i2c_new_trigger_val = PCIE_FPGA_I2C_NEW_TRIGGER_VALUE;
+	else
+		i2c_new_trigger_val = PCIE_FPGA_I2C_NEW_TRIGGER_VALUE + 0x80;
+
+	iowrite32(i2c_new_trigger_val, pdata->data_base_addr + 
+		  pdata->i2c_contrl_rtc0_config_1);
+
+	/*read done status*/
+	while( 1 ) {
+		flag = ioread32(pdata->data_base_addr + 
+				pdata->i2c_contrl_rtc0_stats);
+		if(flag == 0) {
+		/*In normal case:
+		observed chk_state_cnt(10~120) times can get i2c rtc0 done status. */
+			if( chk_state_cnt > 500 ) {
+				flag = -EAGAIN;
+				break;
+			}
+			usleep_range(50, 100);
+			chk_state_cnt++;
+			continue;
+		} else {
+			break;
+		}
+	}
+	msleep(1);
+
+	return flag;
+}
+
+static int fpga_i2c_set_data(struct bin_attribute *attr, loff_t offset, char *data, int i2c_slave_addr)
+{
+	int cnt = 0;
+	int chk_state_cnt = 0;
+	struct eeprom_bin_private_data *pdata = NULL;
+	u32  flag = 0;
+	u32  i2c_new_trigger_val = 0;
+
+	pdata = attr->private;
+
+	/*Select i2c protocol profile*/
+	iowrite32(0x1, pdata->data_base_addr + pdata->i2c_mgmt_rtc0_profile);
+
+	/*clean read data*/
+	for( cnt=0 ; cnt < (PCIE_FPGA_I2C_MAX_LEN/4); cnt++){
+		iowrite32(0x0, pdata->data_base_addr + 
+			  (pdata->i2c_rtc_write_data + (4 * cnt)));
+	}
+
+	/* Prepare date to set into data registor*/
+	iowrite32(data[0], pdata->data_base_addr + pdata->i2c_rtc_write_data);
+
+	/*clean done status*/
+	iowrite32(0x3, pdata->data_base_addr + pdata->i2c_contrl_rtc0_stats);
+
+	/*set write slave addr*/
+	iowrite32(EEPROM_ALLOW_SET_LEN | (i2c_slave_addr << 8), 
+		  pdata->data_base_addr + pdata->i2c_contrl_rtc0_config_0);
+
+	/*triger*/
+	i2c_new_trigger_val = PCIE_FPGA_I2C_NEW_TRIGGER_VALUE + offset;
+	iowrite32(i2c_new_trigger_val, pdata->data_base_addr + 
+		  pdata->i2c_contrl_rtc0_config_1);
+
+	/*read done status*/
+	while(1) {
+		flag = ioread32(pdata->data_base_addr + 
+				pdata->i2c_contrl_rtc0_stats);
+		if(flag == 0) {
+			/*In normal case:
+			observed chk_state_cnt(10~120) times can get i2c rtc0 done status. */
+			if(chk_state_cnt > 500) {
+				flag = -EAGAIN;
+				break;
+			}
+			usleep_range(50, 100);
+			chk_state_cnt++;
+			continue;
+		} else {
+			break;
+		}
+	}
+	msleep(1);
+
+	return flag;
+}
+
+static ssize_t fpga_i2c_read_data(struct bin_attribute *attr, u8 *data)
+{
+	int cnt = 0;
+	u32  read_status = 0;
+	ssize_t byte_size = 0;
+	struct eeprom_bin_private_data *pdata = NULL;
+
+	pdata = attr->private;
+
+	for( cnt=0 ; cnt < (PCIE_FPGA_I2C_MAX_LEN/4); cnt++){
+		read_status = ioread32(pdata->data_base_addr + 
+				      (pdata->i2c_rtc_read_data + cnt*4));
+
+		*(data + cnt*4) = read_status & 0xff;
+		*(data + cnt*4 + 1) = (read_status >> 8) & 0xff;
+		*(data + cnt*4 + 2) =  (read_status >> 16) & 0xff;
+		*(data + cnt*4 + 3) =  (read_status >> 24) & 0xff;
+
+		byte_size = cnt*4 + 3;
+	}
+
+	return byte_size + 1;
+}
+
+static int get_port_present_status(struct bin_attribute *attr)
+{
+	int present = 0;
+	struct eeprom_bin_private_data *pdata = NULL;
+
+	fpga_read_port_status_value(attr);
+
+	pdata = attr->private;
+	/*
+	 * get present status:
+	* regval:0 is   present, convert
+	* regval:1 is unpresent, convert
+	*/
+	if(pdata->port_num == FPGA_LDB_SFP_PORT1_NO) {  /*sfp:65*/
+		present = !((SFP_PORT0_ABS(
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data))
+			& 0x1);
+	} else if(pdata->port_num == FPGA_LDB_SFP_PORT2_NO) { /*sfp:66*/
+		present = !((SFP_PORT1_ABS(
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].sfp_input_data))
+			& 0x1);
+	} else {
+		if(pdata->port_num <= FPGA_LDB_QSFP_PORT_NUM) { /*qsfp:1~32*/
+			present = !
+			((fpga_ctl->pci_fpga_dev[pdata->fpga_type].qsfp_present
+			>>(pdata->port_num - 1)) & 0x1);
+		} else { /*qsfp:33~64*/
+			present = 
+			!((fpga_ctl->pci_fpga_dev[pdata->fpga_type].qsfp_present >>
+			(pdata->port_num - 33)) & 0x1);
+		}
+	}
+
+	return present;
+}
+
+static ssize_t
+sfp_eeprom_read(struct file *filp, struct kobject *kobj,
+             struct bin_attribute *attr,
+             char *buf, loff_t off, size_t count, int *page)
+{
+	int state = 0;
+	int page_num, slice;
+	char set_page_num[1] = {0};
+	struct eeprom_bin_private_data *pdata = NULL;
+	pdata = attr->private;
+
+	ssize_t byte_cnt;
+
+	u8 data[128] = {0};
+
+	slice = off / OPTOE_PAGE_SIZE;
+	/*Cross page case, calculate number of count in current page*/
+	if ((off + count) > (slice * OPTOE_PAGE_SIZE + OPTOE_PAGE_SIZE))
+		count = slice * OPTOE_PAGE_SIZE + OPTOE_PAGE_SIZE - off;
+
+	if(slice == 0){
+		if((state = fpga_i2c_ready_to_read(attr, EEPROM_LOWER_PAGE, 
+			pdata->i2c_slave_addr)) != 1)
+			goto exit_err;
+
+		byte_cnt = fpga_i2c_read_data(attr, &data[0]);
+	} else if(slice == 1){
+		if((state = fpga_i2c_ready_to_read(attr, EEPROM_UPPER_PAGE, 
+			pdata->i2c_slave_addr)) != 1)
+			goto exit_err;
+
+		byte_cnt = fpga_i2c_read_data(attr, &data[0]);
+	} else {
+		page_num = slice - 1;
+		if( pdata->port_num <= FPGA_QSFP_PORT_NUM){ /*qsfp page1~0xff*/
+			set_page_num[0] = page_num;
+			if( (state = fpga_i2c_set_data(attr, 
+				OPTOE_PAGE_SELECT_REG, set_page_num, 
+				pdata->i2c_slave_addr)) != 1)
+				goto exit_err;
+
+			if((state = fpga_i2c_ready_to_read(attr, 
+				EEPROM_UPPER_PAGE, 
+				pdata->i2c_slave_addr)) != 1)
+				goto exit_err;
+
+			byte_cnt = fpga_i2c_read_data(attr, &data[byte_cnt]);
+			*page = page_num;
+		} else {/*sfp support a2(0x51), cat behind a0(0x50)*/
+			if(page_num == 1){ /*a2 lower page*/
+				if((state = fpga_i2c_ready_to_read(attr, 
+					EEPROM_LOWER_PAGE, 
+					TWO_ADDR_0X51)) != 1)
+					goto exit_err;
+
+				byte_cnt = fpga_i2c_read_data(attr, &data[0]);
+			} else if (page_num == 2){ /*a2 page0*/
+				set_page_num[0] = 0;
+				if((state = fpga_i2c_set_data(attr, 
+					OPTOE_PAGE_SELECT_REG, set_page_num,
+					TWO_ADDR_0X51))!=1)
+					goto exit_err;
+
+				if((state = fpga_i2c_ready_to_read(attr, 
+					EEPROM_UPPER_PAGE, TWO_ADDR_0X51)) != 1)
+					goto exit_err;
+
+				byte_cnt = fpga_i2c_read_data(attr, &data[0]);
+			} else {
+				set_page_num[0] = page_num - 2;
+				if((state = fpga_i2c_set_data(attr, 
+					OPTOE_PAGE_SELECT_REG, set_page_num,
+					TWO_ADDR_0X51) != 1)) /*set page from 1*/
+					goto exit_err;
+
+				if((state = fpga_i2c_ready_to_read(attr, 
+					EEPROM_UPPER_PAGE, 
+					TWO_ADDR_0X51)) != 1)
+					goto exit_err;
+
+				byte_cnt = fpga_i2c_read_data(attr, 
+						&data[byte_cnt]);
+				*page = page_num-2;
+			}
+		}
+	}
+	memcpy(buf, &data[off%128], count);
+
+	return count;
+
+exit_err:
+	pcie_err("%s ERROR(%d): Port%d pcie get done status failed!!", show_date_time(), state, pdata->port_num);
+
+	return -EBUSY;
+}
+
+static ssize_t sfp_bin_read(struct file *filp, struct kobject *kobj,
+	struct bin_attribute *attr,
+	char *buf, loff_t off, size_t count)
+{
+	int present;
+	int page = 0;
+	int state = 0;
+	int i2c_slave_addr;
+	char set_page_num[1] ={0};
+	ssize_t retval = 0;
+	struct eeprom_bin_private_data *pdata = NULL;
+	pdata = attr->private;
+
+	if (unlikely(!count))
+		return count;
+
+	mutex_lock(&update_lock);
+
+	present = get_port_present_status(attr);
+	if(!present) { /*unpresent*/
+		mutex_unlock(&update_lock);
+		return -ENODEV;
+	}
+	mutex_unlock(&update_lock);
+
+	/*
+	 * Read data from chip, protecting against concurrent updates
+	 * from this host
+	*/
+	mutex_lock(&update_lock);
+	while (count) {
+		ssize_t status;
+
+		status = sfp_eeprom_read(filp, kobj, attr, buf, off, count, 
+						&page);
+		if (status <= 0) {
+			if (retval == 0)
+				retval = status;
+			break;
+		}
+
+		buf += status;
+		off += status;
+		count -= status;
+		retval += status;
+	}
+	/*
+	 * return the page register to page 0 - why?
+	 * We either have to set the page register to 0 on every access
+	 * to it, or restore it to 0 whenever we change it.  Otherwise,
+	 * accesses to page 0 would actually go to whatever the last page
+	 * was.  Assume more accesses to page 0 than all other pages
+	 * combined, so less total accesses if we always leave it at page 0
+	 */
+	if((page > 0) && (pdata->pageable)) {
+		i2c_slave_addr =
+		(pdata->port_num > FPGA_QSFP_PORT_NUM) ? 
+					TWO_ADDR_0X51 : pdata->i2c_slave_addr;
+
+		if((state = fpga_i2c_set_data(attr, OPTOE_PAGE_SELECT_REG, 
+			set_page_num, i2c_slave_addr)) != 1) { /*set page to 0*/
+			mutex_unlock(&update_lock);
+			goto exit_err;
+		}
+	}
+	mutex_unlock(&update_lock);
+
+	return retval;
+
+exit_err:
+	pcie_err("%s ERROR(%d): Port%d pcie get done status failed!!", show_date_time(), state, pdata->port_num);
+
+	return -EBUSY;
+}
+
+static ssize_t
+sfp_eeprom_write(struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+{
+	int state = 0;
+	int page_num, slice, offset;
+	char set_page_num[1] = {0};
+	struct eeprom_bin_private_data *pdata = NULL;
+	pdata = attr->private;
+
+	slice = off / OPTOE_PAGE_SIZE;
+	page_num = slice - 1;
+	offset = off;
+
+	if(page_num > 0){
+		set_page_num[0] = page_num;
+		if((state = fpga_i2c_set_data(attr, OPTOE_PAGE_SELECT_REG, 
+				set_page_num, pdata->i2c_slave_addr)) != 1)
+			goto exit_err;
+
+		offset = OPTOE_PAGE_SIZE + (off % OPTOE_PAGE_SIZE);
+	}
+
+	if((state = fpga_i2c_set_data(attr, offset, buf, 
+			pdata->i2c_slave_addr)) != 1)
+		goto exit_err;
+
+	if(page_num > 0){
+		set_page_num[0] = 0;
+		if((state = fpga_i2c_set_data(attr, OPTOE_PAGE_SELECT_REG, 
+				set_page_num, pdata->i2c_slave_addr)) != 1)
+			goto exit_err;
+	}
+
+	return count;
+
+exit_err:
+	pcie_err("%s ERROR(%d): Port%d pcie set failed!!", show_date_time(), state, pdata->port_num);
+
+	return -EBUSY;
+}
+
+static ssize_t sfp_bin_write(struct file *filp, struct kobject *kobj,
+                             struct bin_attribute *attr,
+                             char *buf, loff_t off, size_t count)
+{
+	int present;
+	ssize_t status = 0;
+
+	if (unlikely(!count) ||
+		likely(count > EEPROM_ALLOW_SET_LEN))//only allow count = 1
+		return count;
+
+	mutex_lock(&update_lock);
+
+	present = get_port_present_status(attr);
+	if( !present ) { /*unpresent*/
+		mutex_unlock(&update_lock);
+		return -ENODEV;
+	}
+	mutex_unlock(&update_lock);
+
+	/*
+	 * Write data to chip, protecting against concurrent updates
+	 * from this host.
+	 */
+	mutex_lock(&update_lock);
+
+	status = sfp_eeprom_write(attr, buf, off, count);
+
+	mutex_unlock(&update_lock);
+
+	return status;
+}
+
+static int check_qsfp_eeprom_pageable(struct bin_attribute *eeprom)
+{
+	int ret = 0;
+	int not_pageable;
+	u8 identifier_reg;
+	u8 pageable_reg;
+	u32 read_status = 0;
+
+	struct eeprom_bin_private_data *pdata = NULL;
+
+	pdata = eeprom->private;
+
+	if(fpga_i2c_ready_to_read(eeprom, EEPROM_LOWER_PAGE, 
+					pdata->i2c_slave_addr) != 1)
+		return ret;
+
+	read_status = ioread32(pdata->data_base_addr + 
+				(pdata->i2c_rtc_read_data));
+
+	identifier_reg = read_status & 0xff;
+	pageable_reg = (read_status >> 16) & 0xff;  /*check on bit2*/
+
+	if(identifier_reg == QSFPDD_TYPE)
+		not_pageable = CMIS_NOT_PAGEABLE;
+	else
+		not_pageable = QSFP_NOT_PAGEABLE;
+
+	if(pageable_reg & not_pageable) /*not support*/
+		pdata->pageable = 0;
+	else
+		pdata->pageable = 1;
+
+	return pdata->pageable;
+}
+
+static int sfp_sysfs_eeprom_init(struct kobject *kobj, 
+				struct bin_attribute *eeprom)
+{
+	int err;
+	int ret;
+	int present = 0;
+	struct eeprom_bin_private_data *pdata = NULL;
+
+	pdata = eeprom->private;
+
+	sysfs_bin_attr_init(eeprom);
+	eeprom->attr.name   = EEPROM_SYSFS_NAME;
+	eeprom->attr.mode   = S_IWUSR | S_IRUGO;
+	eeprom->read        = sfp_bin_read;
+	eeprom->write       = sfp_bin_write;
+
+	mutex_lock(&update_lock);
+
+	present = get_port_present_status(eeprom);
+
+	if(pdata->port_num > FPGA_QSFP_PORT_NUM){ /*sfp*/
+		if( !present ) { /*unpresent*/
+			eeprom->size = TWO_ADDR_NO_0X51_SIZE;
+		} else {
+			ret = fpga_read_sfp_ddm_status_value(eeprom); /*check support_a2 and pageable*/
+			if(ret < 0) {
+				pcie_err("Err: PCIE device port eeprom is empty");
+				mutex_unlock(&update_lock);
+				return ret;
+			}
+
+			if(!(pdata->sfp_support_a2))/*no A2(0x51)*/
+				eeprom->size = TWO_ADDR_NO_0X51_SIZE;
+			else
+				eeprom->size = ((pdata->sfp_support_a2) && 
+						(!pdata->pageable) ) ? 
+						TWO_ADDR_EEPROM_UNPAGED_SIZE :
+						TWO_ADDR_EEPROM_SIZE;
+		}
+	} else { /*qsfp*/
+		if(!present)/*unpresent*/
+			eeprom->size = OPTOE_ARCH_PAGES;
+		else
+			eeprom->size = (check_qsfp_eeprom_pageable(eeprom)) ? 
+					ONE_ADDR_EEPROM_SIZE : 
+					ONE_ADDR_EEPROM_UNPAGED_SIZE;
+	}
+
+	mutex_unlock(&update_lock);
+
+	/* Create eeprom file */
+	err = sysfs_create_bin_file(kobj, eeprom);
+	if (err)
+		return err;
+
+	return 0;
+}
+
+static int sys_fpga_stat_probe (struct platform_device *pdev)
+{
+	int cnt = 0, status = 0, port_index = 0;
+	int err_cnt, disable_cnt, release_cnt;
+	int find_flag = 0; /*UDB and LDB*/
+	int err = 0;
+	int fpga_no = 0;
+	struct pci_dev *pcidev, *pcidev_from;
+
+	u16 id16 = 0;
+
+	/* Find Accton register memory space */
+	for(cnt = 0 ; cnt < FPGA_NUM ; cnt++){
+		pcidev = pci_get_device(PCI_VENDOR_ID_ACCTON, 
+					PCI_DEVICE_ID_ACCTON, (cnt == 0) 
+					? NULL : pcidev_from);
+
+		/*Init*/
+		fpga_ctl->pci_dev_addr[cnt] = NULL;
+
+		if (!pcidev && !cnt ) { /*Failed at first time*/
+			return -ENODEV;
+		}
+		fpga_ctl->pci_dev_addr[cnt] = pcidev;
+
+		/* Enable device: aAk low-level code to enable I/O and memory */
+		err = pci_enable_device(pcidev);
+		if (err != 0) {
+			pcie_err("Cannot enable PCI(%d) device\n", cnt);
+			disable_cnt = cnt - 1;
+			status = -ENODEV;
+			goto exit_pci_disable;
+		}
+
+		if(pci_read_config_word(pcidev, PCI_SUBSYSTEM_ID, &id16)){
+			disable_cnt = cnt;
+			status = -ENODEV;
+			goto exit_pci_disable;
+		}
+
+		pcie_info("Found PCI Device: %s", FPGA_NAME[id16]);
+
+		err = pci_request_regions(pcidev, FPGA_NAME[id16]);
+		if (err != 0){
+			pcie_err("[%s] cannot request regions\n",  FPGA_NAME[id16]);
+			release_cnt = cnt - 1;
+			disable_cnt = cnt;
+			goto exit_pci_release;
+		}
+
+		switch(id16){
+		case PCI_SUBSYSTEM_ID_UDB:
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].fpga_pdev = pcidev;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].id = PCI_SUBSYSTEM_ID_UDB;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].aslpc_cpld1_offset = ASLPC_DEV_UDB_CPLD1_PCIE_START_OFFST;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].aslpc_cpld2_offset = ASLPC_DEV_UDB_CPLD2_PCIE_START_OFFST;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr = pci_iomap(pcidev, BAR0_NUM, 0); /*0: means access to the complete BAR*/
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_mmio_start = pci_resource_start(pcidev, BAR0_NUM);
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_mmio_len = pci_resource_len(pcidev, BAR0_NUM);
+
+			/*Init eeprom (UDB)private data: I/O base address*/
+			for(port_index = 0 ; port_index < FPGA_UDB_QSFP_PORT_NUM ; port_index++)
+				pcie_udb_eeprom_bin_private_data[port_index].data_base_addr = 
+					fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr;
+
+			pcie_info("(BAR%d resource: Start=0x%lx, Length=%lx)", BAR0_NUM,
+				 (unsigned long)fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_mmio_start,
+				 (unsigned long)fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_mmio_len);
+
+			find_flag++;
+			break;
+		case PCI_SUBSYSTEM_ID_LDB:
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].fpga_pdev = pcidev;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].id = PCI_SUBSYSTEM_ID_LDB;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].aslpc_cpld1_offset = ASLPC_DEV_LDB_CPLD1_PCIE_START_OFFST;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].aslpc_cpld2_offset = ASLPC_DEV_LDB_CPLD2_PCIE_START_OFFST;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr = pci_iomap(pcidev, BAR0_NUM, 0); /*0: means access to the complete BAR*/
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_mmio_start = pci_resource_start(pcidev, BAR0_NUM);
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_mmio_len = pci_resource_len(pcidev, BAR0_NUM);
+
+			/*Init eeprom (LDB)private data: I/O base address*/
+			for(port_index = 0 ; port_index < (FPGA_LDB_QSFP_PORT_NUM + FPGA_LDB_SFP_PORT_NUM) ; port_index++)
+				pcie_ldb_eeprom_bin_private_data[port_index].data_base_addr = 
+					fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr;
+
+			pcie_info("(BAR%d resource: Start=0x%lx, Length=%lx)", BAR0_NUM,
+				 (unsigned long)fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_mmio_start,
+				 (unsigned long)fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_mmio_len);
+
+			find_flag++;
+			break;
+		case PCI_SUBSYSTEM_ID_SMB:
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].fpga_pdev = pcidev;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].id = PCI_SUBSYSTEM_ID_SMB;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].aslpc_cpld1_offset = ASLPC_DEV_SMB_CPLD_PCIE_START_OFFST;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].aslpc_cpld2_offset = 0;
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].data_base_addr = pci_iomap(pcidev, BAR0_NUM, 0); /*0: means access to the complete BAR*/
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].data_mmio_start = pci_resource_start(pcidev, BAR0_NUM);
+			fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].data_mmio_len = pci_resource_len(pcidev, BAR0_NUM);
+
+			pcie_info("(BAR%d resource: Start=0x%lx, Length=%lx)", BAR0_NUM,
+                        	 (unsigned long)fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].data_mmio_start,
+				 (unsigned long)fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].data_mmio_len);
+			break;
+		default:
+			status = -ENODEV;
+			break;
+		}
+		pcidev_from = pcidev;
+	}
+	release_cnt = cnt;
+	disable_cnt = cnt;
+
+	if (find_flag != (FPGA_NUM-1)) {
+		dev_err(&pdev->dev, "Failed found UDB/LDB FPAG device!!\n");
+		status = -ENODEV;
+		goto exit_pci_iounmap;
+	}
+
+	status = sysfs_create_group(&pdev->dev.kobj, &fpga_port_stat_group);
+	if (status) {
+		goto exit_pci_iounmap;
+	}
+
+	mutex_lock(&update_lock);
+
+	/*set gpio input/output*/
+	iowrite32(0x707, 
+		fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr +
+			SFP_LDB_GPIO1_DATA_EN);
+
+	/* QSFP Port LED: Init port Enable >> LDB/UDB (0 >> 1) */
+	for(fpga_no = PCI_SUBSYSTEM_ID_LDB; 
+	    fpga_no >= PCI_SUBSYSTEM_ID_UDB; fpga_no--){
+		for(cnt = 0; cnt <= 1; cnt++) {
+			iowrite8(0xff, 
+				 fpga_ctl->pci_fpga_dev[fpga_no].data_base_addr +
+				 fpga_ctl->pci_fpga_dev[fpga_no].aslpc_cpld1_offset +
+				 0xb0 + cnt);
+		}
+		for(cnt = 0; cnt <= 1; cnt++) {
+			iowrite8(0xff, fpga_ctl->pci_fpga_dev[fpga_no].data_base_addr +
+			fpga_ctl->pci_fpga_dev[fpga_no].aslpc_cpld2_offset + 0xb0 + cnt);
+		}
+	}
+    
+	/* QSFP Port LED: Init present >> LDB/UDB (1 >> 0) */
+	for(fpga_no = PCI_SUBSYSTEM_ID_LDB; 
+	    fpga_no >= PCI_SUBSYSTEM_ID_UDB; fpga_no--){
+		for(cnt = 0; cnt <= 1; cnt++){
+			iowrite8(0x0, fpga_ctl->pci_fpga_dev[fpga_no].data_base_addr +
+				 fpga_ctl->pci_fpga_dev[fpga_no].aslpc_cpld1_offset +
+				 0xb8 + cnt);
+		}
+		for(cnt = 0; cnt <= 1; cnt++) {
+			iowrite8(0x0, fpga_ctl->pci_fpga_dev[fpga_no].data_base_addr +
+			fpga_ctl->pci_fpga_dev[fpga_no].aslpc_cpld2_offset +
+			0xb8 + cnt);
+		}
+	}
+	/* SFP Port LED: Init 2XSFP Port Eanble & Present */
+	iowrite8(0x3, 
+		 fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr +
+		 fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].aslpc_cpld1_offset +
+		 0xbd);
+
+	mutex_unlock(&update_lock);
+
+	/*get version*/
+	fpga_ctl->udb_version = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr);
+	fpga_ctl->ldb_version = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr);
+	fpga_ctl->smb_version = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_SMB].data_base_addr);
+
+	fpga_ctl->udb_cpld1_ver = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + ASLPC_DEV_UDB_CPLD1_PCIE_START_OFFST);
+	fpga_ctl->udb_cpld2_ver = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_UDB].data_base_addr + ASLPC_DEV_UDB_CPLD2_PCIE_START_OFFST);
+	fpga_ctl->ldb_cpld1_ver = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + ASLPC_DEV_LDB_CPLD1_PCIE_START_OFFST);
+	fpga_ctl->ldb_cpld2_ver = ioread32(fpga_ctl->pci_fpga_dev[PCI_SUBSYSTEM_ID_LDB].data_base_addr + ASLPC_DEV_LDB_CPLD2_PCIE_START_OFFST);	
+
+    for (cnt=0;cnt<QSFP_NUM_OF_PORT;cnt++) fpga_ctl->reset_list[cnt] = 0;
+
+	return 0;
+
+exit_pci_iounmap:
+	for(err_cnt = (FPGA_NUM-1); err_cnt >=0; err_cnt--) {
+		pci_iounmap(fpga_ctl->pci_dev_addr[err_cnt], 
+			    fpga_ctl->pci_fpga_dev[err_cnt].data_base_addr);
+	}
+exit_pci_release:
+	for(err_cnt = release_cnt; err_cnt >=0; err_cnt--) {
+		pci_release_regions(fpga_ctl->pci_dev_addr[err_cnt]);
+	}
+exit_pci_disable:
+	for(err_cnt = disable_cnt; err_cnt >=0; err_cnt--) {
+		pci_disable_device(fpga_ctl->pci_dev_addr[err_cnt]);
+	}
+
+	return status;
+}
+
+static int sys_fpga_stat_remove(struct platform_device *pdev)
+{
+	int cnt = 0;
+	sysfs_remove_group(&pdev->dev.kobj, &fpga_port_stat_group);
+
+	for(cnt = (FPGA_NUM - 1); cnt >= 0; cnt--) {
+		pci_iounmap(fpga_ctl->pci_dev_addr[cnt], 
+			    fpga_ctl->pci_fpga_dev[cnt].data_base_addr);
+		pci_release_regions(fpga_ctl->pci_dev_addr[cnt]);
+		pci_disable_device(fpga_ctl->pci_dev_addr[cnt]);
+	}
+
+	return 0;
+}
+
+static int sys_fpga_sfp_probe (struct platform_device *pdev)
+{
+	int status = 0;
+
+	struct pcie_fpga_dev_platform_data *pdata = NULL;
+
+	pdata = pdev->dev.platform_data;
+
+	if (!pdata) {
+		status = -ENOMEM;
+		pcie_err("kzalloc failed\n");
+		goto exit;
+	}
+
+	/*assign port num*/
+	if(pdata->fpga_type==PCIE_FPGA_TYPE_LDB)
+		sprintf(pdata->name, "port%d", pdata->port_num + 32);
+	else
+		sprintf(pdata->name, "port%d", pdata->port_num);
+
+	status = sysfs_create_group(&pdev->dev.kobj, &fpga_eeprom_group);
+	if (status) {
+		pcie_err("sysfs_create_group failed\n");
+		goto exit;
+	}
+
+	/* init eeprom */
+	status = sfp_sysfs_eeprom_init(&pdev->dev.kobj, &pdata->eeprom_bin);
+	if (status) {
+		pcie_err("sfp_sysfs_eeprom_init failed\n");
+		goto exit_remove;
+	}
+
+	return 0;
+
+exit_remove:
+	sysfs_remove_group(&pdev->dev.kobj, &fpga_eeprom_group);
+exit:
+	return status;
+}
+
+static int __exit sys_fpga_sfp_remove(struct platform_device *pdev)
+{
+	struct pcie_fpga_dev_platform_data *pdata = NULL;
+
+	pdata = pdev->dev.platform_data;
+
+	sysfs_remove_bin_file(&pdev->dev.kobj, &pdata->eeprom_bin);
+	sysfs_remove_group(&pdev->dev.kobj, &fpga_eeprom_group);
+
+	return 0;
+}
+
+static struct platform_driver pcie_fpga_port_stat_driver = {
+	.probe      = sys_fpga_stat_probe,
+	.remove     = sys_fpga_stat_remove,
+	.driver     = {
+		.owner = THIS_MODULE,
+		.name  = DRVNAME,
+	},
+};
+
+static struct platform_driver pcie_udb_fpga_driver = {
+	.probe = sys_fpga_sfp_probe,
+	.remove = __exit_p(sys_fpga_sfp_remove),
+	.driver = {
+		.owner = THIS_MODULE,
+		.name = "pcie_udb_fpga_device",
+	}
+};
+
+static struct platform_driver pcie_ldb_fpga_driver = {
+	.probe = sys_fpga_sfp_probe,
+	.remove = __exit_p(sys_fpga_sfp_remove),
+	.driver = {
+		.owner = THIS_MODULE,
+		.name = "pcie_ldb_fpga_device",
+	}
+};
+
+static int __init sys_fpga_init(void)
+{
+	int status = 0;
+	int err_cnt;
+
+	int udb_fpga_cnt = 0, ldb_fpga_cnt = 0, ldb_fpga_sfp_ddm_cnt = 0;
+
+	/*Step1.
+	*Init UDB, LDB port status driver*/
+	 mutex_init(&update_lock);
+
+	fpga_ctl = kzalloc(sizeof(struct sys_fpga_data), GFP_KERNEL);
+	if (!fpga_ctl) {
+		status = -ENOMEM;
+		platform_driver_unregister(&pcie_fpga_port_stat_driver);
+		goto exit;
+	}
+
+	status = platform_driver_register(&pcie_fpga_port_stat_driver);
+	if (status < 0)
+		goto exit;
+
+	fpga_ctl->pdev = platform_device_register_simple(DRVNAME, -1, NULL, 0);
+	if (IS_ERR(fpga_ctl->pdev)) {
+		status = PTR_ERR(fpga_ctl->pdev);
+		goto exit_pci;
+	}
+
+	/*Step2. Init port device driver*/
+
+	/*UDB driver*/
+	status = platform_driver_register(&pcie_udb_fpga_driver);
+	if (status < 0) {
+		pcie_err("Fail to register udb_fpga driver\n");
+		goto exit_pci;
+	}
+
+	/*UDB port1-32 qsfp device*/
+	for (udb_fpga_cnt = 0; udb_fpga_cnt < ARRAY_SIZE(pcie_udb_qsfp_device); 
+		udb_fpga_cnt++) {
+		status = platform_device_register(
+			&pcie_udb_qsfp_device[udb_fpga_cnt]);
+		if (status) {
+			pcie_err("Fail to register (UDB)port%d device.\n", 
+				(udb_fpga_cnt + 1));
+			goto exit_udb_fpga;
+		}
+	}
+	pcie_info("Init UDB_FPGA driver and device.");
+
+	/*LDB driver*/
+	status = platform_driver_register(&pcie_ldb_fpga_driver);
+	if (status < 0) {
+		pcie_err("Fail to register ldb_fpga driver.\n");
+		goto exit_udb_fpga;
+	}
+	
+	/*LDB port33-64, 65-66 qsfp and sfp device*/
+	for (ldb_fpga_cnt = 0; ldb_fpga_cnt < ARRAY_SIZE(pcie_ldb_qsfp_device);
+		ldb_fpga_cnt++) {
+		status = platform_device_register(
+			&pcie_ldb_qsfp_device[ldb_fpga_cnt]);
+		if (status) {
+			pcie_err("Fail to register (LDB)port%d device.\n",
+				(ldb_fpga_cnt + 33));
+			goto exit_ldb_fpga;
+		}
+	}
+	pcie_info("Init LDB_FPGA driver and device.");
+
+	return 0;
+
+exit_ldb_fpga:
+	for(err_cnt=(ldb_fpga_cnt-1);err_cnt>=0;err_cnt--)
+		platform_device_unregister(&pcie_ldb_qsfp_device[err_cnt]);
+	platform_driver_unregister(&pcie_ldb_fpga_driver);
+exit_udb_fpga:
+	for(err_cnt=(udb_fpga_cnt-1);err_cnt>=0;err_cnt--)
+		platform_device_unregister(&pcie_udb_qsfp_device[err_cnt]);
+
+	platform_driver_unregister(&pcie_udb_fpga_driver);
+exit_pci:
+	platform_driver_unregister(&pcie_fpga_port_stat_driver);
+	kfree(fpga_ctl);
+exit:
+	return status;
+}
+
+static void __exit sys_fpga_exit(void)
+{
+	int i = 0;
+
+	/*LDB qsfp port33-64, sfp port65-66*/
+	for (i = 0; i < ARRAY_SIZE(pcie_ldb_qsfp_device); i++)
+		platform_device_unregister(&pcie_ldb_qsfp_device[i]);
+
+	platform_driver_unregister(&pcie_ldb_fpga_driver);
+	pcie_info("Remove LDB_FPGA driver and device.");
+
+	/*UDB qsfp port1-32 */
+	for (i = 0; i < ARRAY_SIZE(pcie_udb_qsfp_device); i++)
+		platform_device_unregister(&pcie_udb_qsfp_device[i]);
+
+	platform_driver_unregister(&pcie_udb_fpga_driver);
+	pcie_info("Remove UDB_FPGA driver and device.");
+
+	/*UDB and LDB get port status*/
+	platform_device_unregister(fpga_ctl->pdev);
+	platform_driver_unregister(&pcie_fpga_port_stat_driver);
+	pcie_info("Remove FPGA status driver.");
+	kfree(fpga_ctl);
+}
+
+
+module_init(sys_fpga_init);
+module_exit(sys_fpga_exit);
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("FPGAs Driver");
+MODULE_LICENSE("GPL");

--- a/ixr7220h4-64d/scripts/h4_64d_platform_init.sh
+++ b/ixr7220h4-64d/scripts/h4_64d_platform_init.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Load required kernel-mode drivers
+
+load_kernel_drivers() {
+    echo "Loading Kernel Drivers"
+    depmod -a
+    modprobe i2c-i801
+    modprobe i2c-dev
+    modprobe i2c-mux
+    modprobe i2c-smbus
+    modprobe i2c-mux-pca954x
+    modprobe sys_fpga
+    modprobe smb_cpld
+    modprobe fan_cpld
+    modprobe scm_cpld
+    modprobe pdbl_cpld
+    modprobe pdbr_cpld
+    modprobe dni_psu
+    modprobe at24
+    modprobe optoe
+    sleep 1
+}
+
+h4_64d_profile()
+{
+    MAC_ADDR=$(ip link show eth0 | grep ether | awk '{print $2}')
+    sed -i "s/switchMacAddress=.*/switchMacAddress=$MAC_ADDR/g" /usr/share/sonic/device/x86_64-nokia_ixr7220_h4-r0/Nokia-IXR7220-H4-64D/profile.ini
+    echo "Nokia-IXR7220-H4-64D: Updated switch mac address ${MAC_ADDR}"
+}
+
+file_exists() {
+    # Wait 10 seconds max till file exists
+    for((i=0; i<10; i++));
+    do
+        if [ -f $1 ]; then
+            return 1
+        fi
+        sleep 1
+    done
+    return 0
+ }
+
+# Install kernel drivers required for i2c bus access
+load_kernel_drivers
+
+# Enumerate I2C Multiplexer
+echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-0/new_device
+sleep 0.5
+# Enumerate I2C Multiplexers
+echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-3/new_device
+echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-5/new_device
+echo pca9548 0x76 > /sys/bus/i2c/devices/i2c-9/new_device
+echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-10/new_device
+echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-11/new_device
+echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-12/new_device
+echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-18/new_device
+echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-19/new_device
+
+# Enumerate eeprom
+echo 24c32 0x51 > /sys/bus/i2c/devices/i2c-20/new_device
+echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-33/new_device
+echo 24c02 0x51 > /sys/bus/i2c/devices/i2c-41/new_device
+echo 24c02 0x51 > /sys/bus/i2c/devices/i2c-26/new_device
+
+# Enumerate CPLDs
+echo smb_cpld 0x60 > /sys/bus/i2c/devices/i2c-6/new_device
+echo fan_cpld 0x33 > /sys/bus/i2c/devices/i2c-25/new_device
+echo scm_cpld 0x35 > /sys/bus/i2c/devices/i2c-51/new_device
+echo pdbl_cpld 0x60 > /sys/bus/i2c/devices/i2c-36/new_device
+echo pdbr_cpld 0x60 > /sys/bus/i2c/devices/i2c-44/new_device
+
+echo dps_2400ab_1 0x58 > /sys/bus/i2c/devices/i2c-33/new_device
+echo dps_2400ab_1 0x59 > /sys/bus/i2c/devices/i2c-41/new_device
+
+# Enumerate Thermal Sensor
+echo tmp75 0x48 > /sys/bus/i2c/devices/i2c-2/new_device
+echo tmp75 0x49 > /sys/bus/i2c/devices/i2c-2/new_device
+echo tmp422 0x4c > /sys/bus/i2c/devices/i2c-14/new_device
+# UDB:
+echo tmp75 0x48 > /sys/bus/i2c/devices/i2c-57/new_device
+echo tmp422 0x4C > /sys/bus/i2c/devices/i2c-58/new_device
+# LDB:
+echo tmp75 0x4c > /sys/bus/i2c/devices/i2c-65/new_device
+echo tmp422 0x4d > /sys/bus/i2c/devices/i2c-66/new_device
+
+echo tmp75 0x48 > /sys/bus/i2c/devices/i2c-27/new_device
+echo tmp75 0x49 > /sys/bus/i2c/devices/i2c-27/new_device
+echo tmp75 0x48 > /sys/bus/i2c/devices/i2c-34/new_device
+echo tmp75 0x49 > /sys/bus/i2c/devices/i2c-42/new_device
+
+# # Set the PCA9548 mux behavior
+echo -2 > /sys/bus/i2c/devices/0-0072/idle_state
+echo -2 > /sys/bus/i2c/devices/3-0071/idle_state
+echo -2 > /sys/bus/i2c/devices/5-0071/idle_state
+echo -2 > /sys/bus/i2c/devices/9-0076/idle_state
+echo -2 > /sys/bus/i2c/devices/10-0070/idle_state
+echo -2 > /sys/bus/i2c/devices/11-0070/idle_state
+echo -2 > /sys/bus/i2c/devices/12-0070/idle_state
+echo -2 > /sys/bus/i2c/devices/18-0070/idle_state
+echo -2 > /sys/bus/i2c/devices/19-0070/idle_state
+
+file_exists /sys/bus/i2c/devices/20-0051/eeprom
+status=$?
+if [ "$status" == "1" ]; then
+    chmod 644 /sys/bus/i2c/devices/20-0051/eeprom
+    h4_64d_profile
+else
+    echo "SYSEEPROM file not foud"
+fi
+
+chmod 644 /sys/bus/i2c/devices/26-0051/eeprom
+chmod 644 /sys/bus/i2c/devices/33-0050/eeprom
+chmod 644 /sys/bus/i2c/devices/41-0051/eeprom
+
+exit 0

--- a/ixr7220h4-64d/service/h4_64d_platform_init.service
+++ b/ixr7220h4-64d/service/h4_64d_platform_init.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nokia-IXR7220-H4-64D Platform Service
+After=sysinit.target
+Before=pmon.service determine-reboot-cause.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/h4_64d_platform_init.sh
+StandardOutput=tty
+
+[Install]
+WantedBy=multi-user.target

--- a/ixr7220h4-64d/setup.py
+++ b/ixr7220h4-64d/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from setuptools import setup
+os.listdir
+
+setup(
+    name='sonic_platform',
+    version='1.0',
+    description='Module to initialize Nokia IXR7220-H4-64D platforms',
+
+    packages=[        
+        'sonic_platform',
+        'sonic_platform.test'
+    ],
+      
+    package_dir={        
+        'sonic_platform': 'sonic_platform'
+    }
+)

--- a/ixr7220h4-64d/sonic_platform/__init__.py
+++ b/ixr7220h4-64d/sonic_platform/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["platform"]
+from sonic_platform import *

--- a/ixr7220h4-64d/sonic_platform/chassis.py
+++ b/ixr7220h4-64d/sonic_platform/chassis.py
@@ -1,0 +1,406 @@
+"""
+    Module contains an implementation of SONiC Platform Base API and
+    provides the platform information
+"""
+
+try:
+    import os
+    import sys
+    from sonic_platform_base.chassis_base import ChassisBase
+    from sonic_platform.sfp import Sfp
+    from sonic_platform.eeprom import Eeprom
+    from sonic_platform.fan import Fan
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+    from .fan_drawer import RealDrawer
+    from sonic_platform.psu import Psu
+    from sonic_platform.thermal import Thermal
+    from sonic_platform.component import Component
+    from sonic_platform.sfp_event import SfpEvent
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+# Port numbers for SFP List Initialization
+PORT_START = 1
+QSFP_PORT_NUM = 64
+PORT_END = 66
+
+UDB_NAME = "/sys/devices/platform/pcie_udb_fpga_device.{}/eeprom"
+LDB_NAME = "/sys/devices/platform/pcie_ldb_fpga_device.{}/eeprom"
+SCM_PATH = "/sys/bus/i2c/devices/51-0035/"
+SYS_LED_PATH = "/sys/devices/platform/sys_fpga/led_sys"
+MAX_SELECT_DELAY = 10
+
+# Device counts
+FAN_DRAWERS = 4
+FANS_PER_DRAWER = 2
+PSU_NUM = 2
+THERMAL_NUM = 11
+COMPONENT_NUM = 13
+
+SYSLOG_IDENTIFIER = "chassis"
+sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+sonic_logger.set_min_log_priority_info()
+
+class Chassis(ChassisBase):
+    """
+    Nokia platform-specific Chassis class
+        customized for the 7220 H4-64D platform.
+    """
+    STATUS_LED_COLOR_BLUE = 'blue'
+    STATUS_LED_COLOR_GREEN_BLINK = 'green_blink'
+
+    def __init__(self):
+        ChassisBase.__init__(self)
+        self.system_led_supported_color = ['off', 'amber', 'green', 'blue', 'green_blink']
+
+        # Verify optoe driver QSFP-DD eeprom devices were enumerated and exist
+        # then create the sfp nodes
+        for index in range(PORT_START, PORT_START + QSFP_PORT_NUM):
+            port_i2c_map = index
+            if index <= QSFP_PORT_NUM // 2:
+                port_eeprom_path = UDB_NAME.format(index - 1)
+            else:
+                port_eeprom_path = LDB_NAME.format(index - QSFP_PORT_NUM // 2 - 1)
+            if not os.path.exists(port_eeprom_path):
+                sonic_logger.log_info(f"path {port_eeprom_path} didnt exist")
+            sfp_node = Sfp(index, 'QSFPDD', port_eeprom_path, port_i2c_map)
+            self._sfp_list.append(sfp_node)
+
+        port_eeprom_path = LDB_NAME.format(32)
+        if not os.path.exists(port_eeprom_path):
+            sonic_logger.log_info(f"path {port_eeprom_path} didnt exist")
+        sfp_node = Sfp(QSFP_PORT_NUM + 1, 'SFP+', port_eeprom_path, 65)
+        self._sfp_list.append(sfp_node)
+
+        port_eeprom_path = LDB_NAME.format(33)
+        if not os.path.exists(port_eeprom_path):
+            sonic_logger.log_info(f"path {port_eeprom_path} didnt exist")
+        sfp_node = Sfp(QSFP_PORT_NUM + 2, 'SFP+', port_eeprom_path, 66)
+        self._sfp_list.append(sfp_node)
+        self.sfp_event_initialized = False
+        # Instantiate system eeprom object
+        self._eeprom = Eeprom(False, 0, False, 0)
+
+        self._watchdog = None
+        self.sfp_event = None
+        self.max_select_event_returned = None
+
+        # Construct lists fans, power supplies, thermals & components
+        for i in range(THERMAL_NUM):
+            thermal = Thermal(i)
+            self._thermal_list.append(thermal)
+
+        drawer_num = FAN_DRAWERS
+        fan_num_per_drawer = FANS_PER_DRAWER
+        drawer_ctor = RealDrawer
+        for drawer_index in range(drawer_num):
+            drawer = drawer_ctor(drawer_index)
+            self._fan_drawer_list.append(drawer)
+            for fan_index in range(fan_num_per_drawer):
+                fan = Fan(fan_index, drawer_index)
+                drawer._fan_list.append(fan)
+                self._fan_list.append(fan)
+
+        for i in range(PSU_NUM):
+            psu = Psu(i)
+            self._psu_list.append(psu)
+
+        for i in range(COMPONENT_NUM):
+            component = Component(i)
+            self._component_list.append(component)
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of physical SFP ports in a
+            chassis starting from 1.
+
+        Returns:
+            An object dervied from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write(f"SFP index {index} out of range (1-{len(self._sfp_list)})\n")
+        return sfp
+
+    def get_change_event(self, timeout=0):
+        """
+        Returns a nested dictionary containing all devices which have
+        experienced a change at chassis level
+
+        Args:
+            timeout: Timeout in milliseconds (optional). If timeout == 0,
+                this method will block until a change is detected.
+
+        Returns:
+            (bool, dict):
+                - True if call successful, False if not;
+                - A nested dictionary where key is a device type,
+                  value is a dictionary with key:value pairs in the format of
+                  {'device_id':'device_event'},
+                  where device_id is the device ID for this device and
+                        device_event,
+                             status='1' represents device inserted,
+                             status='0' represents device removed.
+                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
+                      indicates that fan 0 has been removed, fan 2
+                      has been inserted and sfp 11 has been removed.
+        """
+        # Initialize SFP event first
+        if not self.sfp_event_initialized:
+            self.sfp_event = SfpEvent()
+            self.sfp_event.initialize()
+            self.max_select_event_returned = PORT_END
+            self.sfp_event_initialized = True
+
+        wait_for_ever = timeout == 0
+        port_dict = {}
+        if wait_for_ever:
+            # xrcvd will call this monitor loop in the "SYSTEM_READY" state
+            # sonic_logger.log_info(" wait_for_ever get_change_event %d" % timeout)
+            timeout = MAX_SELECT_DELAY
+            while True:
+                status = self.sfp_event.check_sfp_status(port_dict, timeout)
+                if port_dict:
+                    break
+        else:
+            # At boot up and in "INIT" state call from xrcvd will have timeout
+            # value return true without change after timeout and will
+            # transition to "SYSTEM_READY"
+            status = self.sfp_event.check_sfp_status(port_dict, timeout)
+
+        if status:
+            return True, {'sfp': port_dict}
+        return True, {'sfp': {}}
+
+    def get_num_psus(self):
+        """
+        Retrieves the num of the psus
+        Returns:
+            int: The num of the psus
+        """
+        return PSU_NUM
+
+    def get_name(self):
+        """
+        Retrieves the name of the chassis
+        Returns:
+            string: The name of the chassis
+        """
+        return self._eeprom.modelstr()
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the chassis
+        Returns:
+            bool: True if chassis is present, False if not
+        """
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the chassis
+        Returns:
+            string: Model/part number of chassis
+        """
+        return self._eeprom.part_number_str()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the chassis
+        Returns:
+            string: Serial number of chassis
+        """
+        return self._eeprom.serial_number_str()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the chassis
+        Returns:
+            bool: A boolean value, True if chassis is operating properly
+            False if not
+        """
+        return True
+
+    def get_base_mac(self):
+        """
+        Retrieves the base MAC address for the chassis
+
+        Returns:
+            A string containing the MAC address in the format
+            'XX:XX:XX:XX:XX:XX'
+        """
+        return self._eeprom.base_mac_addr()
+
+    def get_service_tag(self):
+        """
+        Retrieves the Service Tag of the chassis
+        Returns:
+            string: Service Tag of chassis
+        """
+        return self._eeprom.service_tag_str()
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the chassis
+
+        Returns:
+            string: Revision value of chassis
+        """
+        #Revision is always 0 for 7220-IXR-H4-64D
+        return str(0)
+
+    def get_system_eeprom_info(self):
+        """
+        Retrieves the full content of system EEPROM information for the
+        chassis
+
+        Returns:
+            A dictionary where keys are the type code defined in
+            OCP ONIE TlvInfo EEPROM format and values are their
+            corresponding values.
+        """
+        return self._eeprom.system_eeprom_info()
+
+    def get_thermal_manager(self):
+        """
+        Get thermal manager
+
+        Returns:
+            ThermalManager
+        """
+        from .thermal_manager import ThermalManager
+        return ThermalManager
+
+    def initizalize_system_led(self):
+        """
+        Initizalize system led
+
+        Returns:
+        bool: True if it is successful.
+        """
+        return True
+
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
+        Returns:
+            A tuple (string, string) where the first element is a string
+            containing the cause of the previous reboot. This string must be
+            one of the predefined strings in this class. If the first string
+            is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+            to pass a description of the reboot cause.
+        """
+        result = read_sysfs_file(SCM_PATH + "reset_cause")
+
+        if (int(result, 16) & 0x8) >> 3 == 0:
+            return (self.REBOOT_CAUSE_WATCHDOG, "COMe_WDT")
+        if (int(result, 16) & 0x4) >> 2 == 0:
+            return (self.REBOOT_CAUSE_WATCHDOG, "TCO_WDT")
+        if (int(result, 16) & 0x2) >> 1 == 0:
+            return (self.REBOOT_CAUSE_HARDWARE_OTHER, "SW Reset")
+        if (int(result, 16) & 0x1) == 0:
+            return (self.REBOOT_CAUSE_HARDWARE_OTHER, "COMe Reset")
+
+        return (self.REBOOT_CAUSE_NON_HARDWARE, None)
+
+    def get_watchdog(self):
+        """
+        Retrieves hardware watchdog device on this chassis
+
+        Returns:
+            An object derived from WatchdogBase representing the hardware
+            watchdog device
+
+        Note:
+            We overload this method to ensure that watchdog is only initialized
+            when it is referenced. Currently, only one daemon can open the
+            watchdog. To initialize watchdog in the constructor causes multiple
+            daemon try opening watchdog when loading and constructing a chassis
+            object and fail. By doing so we can eliminate that risk.
+        """
+        try:
+            if self._watchdog is None:
+                from sonic_platform.watchdog import WatchdogImplBase
+                watchdog_device_path = "/dev/watchdog0"
+                self._watchdog = WatchdogImplBase(watchdog_device_path)
+        except ImportError as e:
+            sonic_logger.log_warning(f"Fail to load watchdog {repr(e)}")
+
+        return self._watchdog
+
+    def get_position_in_parent(self):
+        """
+		Retrieves 1-based relative physical position in parent device. If the agent
+        cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0',
+        then the value '-1' is returned
+		Returns:
+		    integer: The 1-based relative physical position in parent device or -1 if
+            cannot determine the position
+		"""
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the system LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   system LED
+
+        Returns:
+            bool: True if system LED state is set successfully, False if not
+        """
+        color_to_value = {
+            'off': '0',
+            'green': '8',
+            'amber': '1',
+            'green_blink': '2',
+            'blue': '4'
+        }
+
+        if color not in self.system_led_supported_color:
+            return False
+
+        value = color_to_value.get(color)
+        if value is None:
+            return False
+
+        write_sysfs_file(SYS_LED_PATH, value)
+        return True
+
+    def get_status_led(self):
+        """
+        Gets the state of the system LED
+
+        Returns:
+            A string, one of the valid LED color strings which could be vendor
+            specified.
+        """
+        result = read_sysfs_file(SYS_LED_PATH)
+
+        if (int(result, 10) & 0x8) == 0x8:
+            return self.STATUS_LED_COLOR_GREEN
+        if (int(result, 10) & 0x4) == 0x4:
+            return self.STATUS_LED_COLOR_BLUE
+        if (int(result, 10) & 0x2) == 0x2:
+            return self.STATUS_LED_COLOR_GREEN_BLINK
+        if (int(result, 10) & 0x1) == 0x1:
+            return self.STATUS_LED_COLOR_AMBER
+        return self.STATUS_LED_COLOR_OFF

--- a/ixr7220h4-64d/sonic_platform/component.py
+++ b/ixr7220h4-64d/sonic_platform/component.py
@@ -1,0 +1,220 @@
+"""
+    NOKIA IXR7220 H4-64D
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Components' (e.g., BIOS, CPLD, FPGA, etc.) available in
+      the platform
+"""
+
+try:
+    import os
+    import subprocess
+    import ntpath
+    from sonic_platform_base.component_base import ComponentBase
+    from sonic_platform.sysfs import read_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+COMPONENT_NUM = 13
+SYSFS_PATH = ["/sys/class/dmi/id/bios_version",
+             "/sys/bus/platform/drivers/sys_fpga/sys_fpga/smb_version",
+             "/sys/bus/platform/drivers/sys_fpga/sys_fpga/udb_version",
+             "/sys/bus/platform/drivers/sys_fpga/sys_fpga/ldb_version",
+             "/sys/bus/i2c/devices/6-0060/code_ver",
+             "/sys/devices/platform/sys_fpga/udb_cpld1_ver",
+             "/sys/devices/platform/sys_fpga/udb_cpld2_ver",
+             "/sys/devices/platform/sys_fpga/ldb_cpld1_ver",
+             "/sys/devices/platform/sys_fpga/ldb_cpld2_ver",
+             "/sys/bus/i2c/devices/25-0033/code_ver",
+             "/sys/bus/i2c/devices/36-0060/code_ver",
+             "/sys/bus/i2c/devices/44-0060/code_ver",
+             "/sys/bus/i2c/devices/51-0035/code_ver"]
+
+class Component(ComponentBase):
+    """Nokia platform-specific Component class"""
+
+    CHASSIS_COMPONENTS = [
+        ["BIOS", "Basic Input/Output System"],
+        ["SMB_FPGA", "Used for managing syetem board"],
+        ["UDB_FPGA", "Used for managing upper QSFPs 1-32"],
+        ["LDB_FPGA", "Used for managing lower QSFPs 33-64 and SFP+"],
+        ["SMB_CPLD", "Used for managing system board"],
+        ["UDB_CPLD1", "Used for managing upper QSFPs 1-32"],
+        ["UDB_CPLD2", "Used for managing upper QSFPs 1-32"],
+        ["LDB_CPLD1", "Used for managing lower QSFPs 33-64 and SFP+"],
+        ["LDB_CPLD2", "Used for managing lower QSFPs 33-64 and SFP+"],
+        ["FAN_CPLD", "Used for managing fans"],
+        ["PDBL_CPLD", "Used for managing left PSU"],
+        ["PDBR_CPLD", "Used for managing right PSU"],
+        ["SCM_CPLD", "Used for managing misc system"]]
+
+    CPLD_UPDATE_COMMAND = ['./vme', '']
+
+    def __init__(self, component_index):
+        self.index = component_index
+        self.name = self.CHASSIS_COMPONENTS[self.index][0]
+        self.description = self.CHASSIS_COMPONENTS[self.index][1]
+        self.sysfs_path = SYSFS_PATH[self.index]
+
+    def _get_command_result(self, cmdline):
+        try:
+            with subprocess.Popen(cmdline.split(), stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT) as proc:
+                _, _ = proc.communicate()
+                stdout = proc.communicate()[0]
+            proc.wait()
+            result = stdout.rstrip('\n')
+        except OSError:
+            result = None
+
+        return result
+
+    def _get_cpld_version(self):
+        return read_sysfs_file(self.sysfs_path)
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+
+        Returns:
+            A string containing the name of the component
+        """
+        return self.name
+
+    def get_model(self):
+        """
+        Retrieves the part number of the component
+        Returns:
+            string: Part number of component
+        """
+        return 'NA'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the component
+        Returns:
+            string: Serial number of component
+        """
+        return 'NA'
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the component
+        Returns:
+            bool: True if  present, False if not
+        """
+        return True
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the component
+        Returns:
+            bool: True if component is operating properly, False if not
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        Returns:
+            integer: The 1-based relative physical position in parent
+            device or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether component is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+
+        Returns:
+            A string containing the description of the component
+        """
+        return self.description
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of the component
+
+        Returns:
+            A string containing the firmware version of the component
+        """
+        return self._get_cpld_version()
+
+    def install_firmware(self, image_path):
+        """
+        Installs firmware to the component
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A boolean, True if install was successful, False if not
+        """
+        image_name = ntpath.basename(image_path)
+        print(f"IXR-7220-H4-64D - install cpld {image_name}")
+
+        # check whether the image file exists
+        if not os.path.isfile(image_path):
+            print(f"ERROR: the cpld image {image_path} doesn't exist ")
+            return False
+
+        # check whether the cpld exe exists
+        if not os.path.isfile('/tmp/vme'):
+            print(f"ERROR: the cpld exe {'/tmp/vme'} doesn't exist ")
+            return False
+
+        self.CPLD_UPDATE_COMMAND[1] = image_name
+
+        success_flag = False
+
+        try:
+            subprocess.check_call(self.CPLD_UPDATE_COMMAND, stderr=subprocess.STDOUT)
+
+            success_flag = True
+        except subprocess.CalledProcessError as e:
+            print(f"ERROR: Failed to upgrade CPLD: rc={e.returncode}")
+
+        if success_flag:
+            print("INFO: Refresh or power cycle is required to finish CPLD installation")
+
+        return success_flag
+
+    def update_firmware(self, _image_path):
+        """
+        Updates firmware of the component
+
+        This API performs firmware update:
+        it assumes firmware installation and loading in a single call.
+        In case platform component requires some extra steps (apart from calling Low Level Utility)
+        to load the installed firmware (e.g, reboot, power cycle, etc.)
+        - this will be done automatically by API
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Raises:
+            RuntimeError: update failed
+        """
+        return False
+
+    def get_available_firmware_version(self, _image_path):
+        """
+        Retrieves the available firmware version of the component
+
+        Note: the firmware version will be read from image
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A string containing the available firmware version of the component
+        """
+        return "N/A"

--- a/ixr7220h4-64d/sonic_platform/eeprom.py
+++ b/ixr7220h4-64d/sonic_platform/eeprom.py
@@ -1,0 +1,175 @@
+"""
+    Nokia 7220 IXR H4-64D
+
+    Module contains platform specific implementation of SONiC Platform
+    Base API and provides the EEPROMs' information.
+
+    The different EEPROMs available are as follows:
+    - System EEPROM : Contains Serial number, Service tag, Base MA
+                      address, etc. in ONIE TlvInfo EEPROM format.
+"""
+
+try:
+    import os
+    from sonic_platform_base.sonic_eeprom.eeprom_tlvinfo import TlvInfoDecoder
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+sonic_logger = logger.Logger('eeprom')
+
+class Eeprom(TlvInfoDecoder):
+    """Nokia platform-specific EEPROM class"""
+
+    I2C_DIR = "/sys/bus/i2c/devices/"
+    FAN_EEPROM_DIR = "/sys/bus/i2c/devices/26-0051/eeprom"
+    def __init__(self, is_psu, psu_index, is_fan, drawer_index):
+        self.is_psu_eeprom = is_psu
+        self.is_fan_eeprom = is_fan
+        self.is_sys_eeprom = not is_psu | is_fan
+        self.service_tag = 'NA'
+        self.part_number = 'NA'
+
+        if self.is_sys_eeprom:
+            self.start_offset = 0
+            self.eeprom_path = self.I2C_DIR + "20-0051/eeprom"
+            # System EEPROM is in ONIE TlvInfo EEPROM format
+            super().__init__(self.eeprom_path, self.start_offset, '', True)            
+            self.base_mac = os.popen("sudo decode-syseeprom -d -m").read().rstrip('\n')
+            self.model_str = "7220 IXR-H4"
+            self.serial_number = os.popen("sudo decode-syseeprom -d -s").read().rstrip('\n')
+
+        elif self.is_psu_eeprom:
+            self.start_offset = 0
+
+        elif self.is_fan_eeprom:
+            self.start_offset = 0
+            self.eeprom_path = self.FAN_EEPROM_DIR
+
+            # Fan EEPROM is in ONIE TlvInfo EEPROM format
+            super().__init__(self.eeprom_path, self.start_offset, '', True)
+            self._load_system_eeprom()
+
+    def _load_system_eeprom(self):
+        """
+        Reads the system EEPROM and retrieves the values corresponding
+        to the codes defined as per ONIE TlvInfo EEPROM format and fills
+        them in a dictionary.
+        """
+        try:
+            # Read System EEPROM as per ONIE TlvInfo EEPROM format.
+            self.eeprom_data = self.read_eeprom()
+        except Exception as e:
+            sonic_logger.log_warning(f"Unable to read system eeprom: {e}")
+            self.base_mac = 'NA'
+            self.serial_number = 'NA'
+            self.part_number = 'NA'
+            self.model_str = 'NA'
+            self.service_tag = 'NA'
+            self.eeprom_tlv_dict = {}
+        else:
+            eeprom = self.eeprom_data
+            self.eeprom_tlv_dict = {}
+
+            if not self.is_valid_tlvinfo_header(eeprom):
+                sonic_logger.log_warning("Invalid system eeprom TLV header")
+                self.base_mac = 'NA'
+                self.serial_number = 'NA'
+                self.part_number = 'NA'
+                self.model_str = 'NA'
+                self.service_tag = 'NA'
+                return
+
+            total_length = (eeprom[9] << 8) | eeprom[10]
+            tlv_index = self._TLV_INFO_HDR_LEN
+            tlv_end = self._TLV_INFO_HDR_LEN + total_length
+
+            while (tlv_index + 2) < len(eeprom) and tlv_index < tlv_end:
+                if not self.is_valid_tlv(eeprom[tlv_index:]):
+                    break
+
+                tlv = eeprom[tlv_index:tlv_index + 2
+                             + eeprom[tlv_index + 1]]
+                code = f"0x{tlv[0]:02X}"
+
+                _, value = self.decoder(None, tlv)
+
+                self.eeprom_tlv_dict[code] = value
+                if eeprom[tlv_index] == self._TLV_CODE_CRC_32:
+                    break
+
+                tlv_index += eeprom[tlv_index+1] + 2
+
+            self.base_mac = self.eeprom_tlv_dict.get(
+                f"0x{self._TLV_CODE_MAC_BASE:X}", 'NA')
+            self.serial_number = self.eeprom_tlv_dict.get(
+                f"0x{self._TLV_CODE_SERIAL_NUMBER:X}", 'NA')
+            self.part_number = self.eeprom_tlv_dict.get(
+                f"0x{self._TLV_CODE_PART_NUMBER:X}", 'NA')
+            self.model_str = self.eeprom_tlv_dict.get(
+                f"0x{self._TLV_CODE_PRODUCT_NAME:X}", 'NA')
+            self.service_tag = self.eeprom_tlv_dict.get(
+                f"0x{self._TLV_CODE_SERVICE_TAG:X}", 'NA')
+
+    def _get_eeprom_field(self, field_name):
+        """
+        For a field name specified in the EEPROM format, returns the
+        presence of the field and the value for the same.
+        """
+        field_start = 0
+        for field in self.format:
+            field_end = field_start + field[2]
+            if field[0] == field_name:
+                return (True, self.eeprom_data[field_start:field_end])
+            field_start = field_end
+
+        return (False, None)
+
+    def serial_number_str(self):
+        """
+        Returns the serial number.
+        """
+        return self.serial_number
+
+    def part_number_str(self):
+        """
+        Returns the part number.
+        """
+        return self.part_number
+
+    def airflow_fan_type(self):
+        """
+        Returns the airflow fan type.
+        """
+        if self.is_psu_eeprom:
+            return int(self.psu_type.encode('hex'), 16)
+        if self.is_fan_eeprom:
+            return int(self.fan_type.encode('hex'), 16)
+        return None
+
+    # System EEPROM specific methods
+    def base_mac_addr(self):
+        """
+        Returns the base MAC address found in the system EEPROM.
+        """
+        return self.base_mac
+
+    def modelstr(self):
+        """
+        Returns the Model name.
+        """
+        return self.model_str
+
+    def service_tag_str(self):
+        """
+        Returns the servicetag number.
+        """
+        return self.service_tag
+
+    def system_eeprom_info(self):
+        """
+        Returns a dictionary, where keys are the type code defined in
+        ONIE EEPROM format and values are their corresponding values
+        found in the system EEPROM.
+        """
+        return self.eeprom_tlv_dict

--- a/ixr7220h4-64d/sonic_platform/fan.py
+++ b/ixr7220h4-64d/sonic_platform/fan.py
@@ -1,0 +1,256 @@
+"""
+    Nokia IXR7220 H4-64D
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Fans' information which are available in the platform
+"""
+
+try:
+    from sonic_platform_base.fan_base import FanBase
+    from sonic_platform.eeprom import Eeprom
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+FANS_PER_DRAWER = 2
+FAN_PN_F2B = "3HE19865AARA01"
+MAX_SPEED = 13600
+FAN_TOLERANCE = 20
+WORKING_IXR7220_FAN_SPEED = 1360
+
+I2C_DIR = "/sys/bus/i2c/devices/i2c-25/25-0033/"
+
+sonic_logger = logger.Logger('fan')
+
+class Fan(FanBase):
+    """Nokia platform-specific Fan class"""
+
+    def __init__(self, fan_index, drawer_index, psu_fan=False, dependency=None):
+        self.is_psu_fan = psu_fan
+
+        if not self.is_psu_fan:
+            # Fan is 1-based in Nokia platforms
+            self.index = drawer_index * FANS_PER_DRAWER + fan_index + 1
+            self.drawer_index = drawer_index + 1
+            self.set_fan_speed_reg = I2C_DIR + f"pwm{self.index}"
+            self.get_fan_speed_reg = I2C_DIR + f"fan{self.index}_speed"
+            self.fan_presence_reg = I2C_DIR + f"fan{self.drawer_index}_present"
+            self.fan_led_reg = I2C_DIR + f"fan{self.drawer_index}_led"
+            self.system_led_supported_color = ['off', 'red', 'green']
+
+            # Fan eeprom
+            self.eeprom = Eeprom(False, 0, True, drawer_index)
+            self.max_fan_speed = MAX_SPEED
+
+        else:
+            # this is a PSU Fan
+            self.index = fan_index
+            self.dependency = dependency
+
+    def get_name(self):
+        """
+        Retrieves the name of the Fan
+
+        Returns:
+            string: The name of the Fan
+        """
+        if not self.is_psu_fan:
+            return f"Fan{self.index}"
+        return f"PSU{self.index} Fan"
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the Fan Unit
+
+        Returns:
+            bool: True if Fan is present, False if not
+        """
+        result = read_sysfs_file(self.fan_presence_reg)
+        if result == '1':
+            return True
+        return False
+
+    def get_model(self):
+        """
+        Retrieves the model number of the Fan
+
+        Returns:
+            string: Model number of Fan. Use part number for this.
+        """
+        return self.eeprom.modelstr()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the Fan
+
+        Returns:
+            string: Serial number of Fan
+        """
+        return self.eeprom.serial_number_str()
+
+    def get_part_number(self):
+        """
+        Retrieves the part number of the Fan
+
+        Returns:
+            string: Part number of Fan
+        """
+        return self.eeprom.part_number_str()
+
+    def get_service_tag(self):
+        """
+        Retrieves the service tag of the Fan
+
+        Returns:
+            string: Service Tag of Fan
+        """
+        return self.eeprom.service_tag_str()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the Fan
+
+        Returns:
+            bool: True if Fan is operating properly, False if not
+        """
+        status = False
+
+        fan_speed = read_sysfs_file(self.get_fan_speed_reg)
+        if fan_speed != 'ERR':
+            if int(fan_speed) > WORKING_IXR7220_FAN_SPEED:
+                status = True
+
+        return status
+
+    def get_direction(self):
+        """
+        Retrieves the fan airflow direction
+        Possible fan directions (relative to port-side of device)
+        Returns:
+            A string, either FAN_DIRECTION_INTAKE or
+            FAN_DIRECTION_EXHAUST depending on fan direction
+        """
+        return self.FAN_DIRECTION_INTAKE
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self.index
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
+
+    def get_speed(self):
+        """
+        Retrieves the speed of a Front FAN in the tray in revolutions per
+                 minute defined by 1-based index
+        :param index: An integer, 1-based index of the FAN to query speed
+        :return: integer, denoting front FAN speed
+        """
+        speed = 0
+
+        fan_speed = read_sysfs_file(self.get_fan_speed_reg)
+        if fan_speed != 'ERR':
+            speed_in_rpm = int(fan_speed)
+        else:
+            speed_in_rpm = 0
+
+        speed = round(100*speed_in_rpm/self.max_fan_speed)
+        speed = min(speed, 100)
+        return speed
+
+    def get_speed_tolerance(self):
+        """
+        Retrieves the speed tolerance of the fan
+
+        Returns:
+            An integer, the percentage of variance from target speed
+            which is considered tolerable
+        """
+        return FAN_TOLERANCE
+
+    def set_speed(self, speed):
+        """
+        Set fan speed to expected value
+        Args:
+            speed: An integer, the percentage of full fan speed to set
+            fan to, in the range 0 (off) to 100 (full speed)
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        if self.is_psu_fan:
+            return False
+
+        if speed in range(0, 10):
+            fandutycycle = 0x00
+        elif speed in range(10, 100):
+            fandutycycle = round((speed*255)/100)
+        else:
+            return False
+
+        rv = write_sysfs_file(self.set_fan_speed_reg, str(fandutycycle))
+        if rv != 'ERR':
+            return True
+        return False
+
+    def set_status_led(self, _color):
+        """
+        Set led to expected color
+        Args:
+            color: A string representing the color with which to set the
+                   fan module status LED
+        Returns:
+            bool: True if set success, False if fail.
+
+            No indivial led for each H4-64D fans
+        """
+        return False
+
+    def get_status_led(self):
+        """
+        Gets the state of the fan drawer status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        if not self.get_presence():
+            return self.STATUS_LED_COLOR_OFF
+
+        result = read_sysfs_file(self.fan_led_reg)
+
+        if result in {"base", "off"}:
+            return self.STATUS_LED_COLOR_OFF
+        if result == "green":
+            return self.STATUS_LED_COLOR_GREEN
+        if result == "red":
+            return self.STATUS_LED_COLOR_RED
+        return 'N/A'
+
+    def get_target_speed(self):
+        """
+        Retrieves the target (expected) speed of the fan
+
+        Returns:
+            An integer, the percentage of full fan speed, in the range 0
+            (off) to 100 (full speed)
+        """
+        speed = 0
+
+        fan_duty = read_sysfs_file(self.set_fan_speed_reg)
+        if fan_duty != 'ERR':
+            dutyspeed = int(fan_duty)
+            if dutyspeed == 0:
+                speed = 0
+            else:
+                speed = round((dutyspeed*100)/255)
+
+        return int(speed)

--- a/ixr7220h4-64d/sonic_platform/fan_drawer.py
+++ b/ixr7220h4-64d/sonic_platform/fan_drawer.py
@@ -1,0 +1,167 @@
+"""
+    Nokia IXR7220 H4-64D
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Fan Drawer status which is available in the platform
+"""
+
+try:
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+    from sonic_platform.eeprom import Eeprom
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+FANS_PER_DRAWER = 2
+I2C_DIR = "/sys/bus/i2c/devices/i2c-25/25-0033/"
+
+sonic_logger = logger.Logger('fan_drawer')
+
+class NokiaFanDrawer(FanDrawerBase):
+    """
+    Nokia platform-specific NokiaFanDrawer class
+    """
+    def __init__(self, index):
+        super().__init__()
+        self._index = index + 1
+        self.eeprom = Eeprom(False, 0, True, index)
+        self.fan_led_color = ['off', 'red', 'green']
+        self.fan_led_reg = I2C_DIR + f"fan{self._index}_led"
+        self.fan_presence_reg = I2C_DIR + f"fan{self._index}_present"
+
+    def get_index(self):
+        """
+        Retrieves the index of the Fan Drawer
+        Returns:
+            int: the Fan Drawer's index
+        """
+        return self._index
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the Fan Drawer
+        Returns:
+            bool: return True if the Fan Drawer is present
+        """
+        result = read_sysfs_file(self.fan_presence_reg)
+        return result == '1'
+
+    def get_model(self):
+        """
+        Retrieves the model number of the Fan Drawer
+        Returns:
+            string: Part number of Fan Drawer
+        """
+        return self.eeprom.modelstr()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the Fan Drawer
+        Returns:
+            string: Serial number of Fan
+        """
+        return self.eeprom.serial_number_str()
+
+    def get_part_number(self):
+        """
+        Retrieves the part number of the Fan Drawer
+
+        Returns:
+            string: Part number of Fan
+        """
+        return self.eeprom.part_number_str()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the Fan Drawer
+        Returns:
+            bool: True if Fan is operating properly, False if not
+        """
+        good_fan = 0
+        for fan in self._fan_list:
+            if fan.get_status():
+                good_fan = good_fan + 1
+
+        if good_fan == FANS_PER_DRAWER:
+            return True
+        return False
+
+    def get_direction(self):
+        """
+        Retrieves the direction of the Fan Drawer
+        Returns:
+            string: direction string
+        """
+        return 'intake'
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the fan drawer status LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   fan drawer status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if not
+        """
+        if not self.get_presence():
+            return False
+        if color not in self.fan_led_color:
+            return False
+
+        rv = write_sysfs_file(self.fan_led_reg, color)
+        if rv != 'ERR':
+            return True
+        return False
+
+    def get_status_led(self):
+        """
+        Gets the state of the fan drawer LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings
+        """
+        if not self.get_presence():
+            return self.STATUS_LED_COLOR_OFF
+
+        result = read_sysfs_file(self.fan_led_reg)
+
+        if result in {"base", "off"}:
+            return self.STATUS_LED_COLOR_OFF
+        if result == "green":
+            return self.STATUS_LED_COLOR_GREEN
+        if result == "red":
+            return self.STATUS_LED_COLOR_RED
+        return 'N/A'
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self._index
+
+class RealDrawer(NokiaFanDrawer):
+    """
+    For Nokia platforms with fan drawer(s)
+    """
+    def __init__(self, index):
+        super().__init__(index)
+        self._name = f'drawer{self._index}'
+
+    def get_name(self):
+        """
+        return module name
+        """
+        return self._name

--- a/ixr7220h4-64d/sonic_platform/platform.py
+++ b/ixr7220h4-64d/sonic_platform/platform.py
@@ -1,0 +1,19 @@
+"""
+    Module contains an implementation of SONiC Platform Base API and
+    provides the platform information
+"""
+
+try:
+    from sonic_platform_base.platform_base import PlatformBase
+    from sonic_platform.chassis import Chassis
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+class Platform(PlatformBase):
+    """
+    Nokia platform-specific class
+    """
+
+    def __init__(self):
+        PlatformBase.__init__(self)
+        self._chassis = Chassis()

--- a/ixr7220h4-64d/sonic_platform/psu.py
+++ b/ixr7220h4-64d/sonic_platform/psu.py
@@ -1,0 +1,294 @@
+"""
+    Nokia IXR7220 H4-64D
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the PSUs' information which are available in the platform
+"""
+
+try:
+    from sonic_platform.sysfs import read_sysfs_file
+    from sonic_platform_base.psu_base import PsuBase
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+sonic_logger = logger.Logger('psu')
+PSU_NUM = 2
+PSU_DIR = ["/sys/bus/i2c/devices/41-0059/",
+           "/sys/bus/i2c/devices/33-0058/"]
+REG_DIR = "/sys/bus/i2c/devices/6-0060/"
+PSU_EEPROM = ["/sys/bus/i2c/devices/41-0051/eeprom",
+              "/sys/bus/i2c/devices/33-0050/eeprom"]
+
+MAX_VOLTAGE = 13
+MIN_VOLTAGE = 11
+
+class Psu(PsuBase):
+    """Nokia platform-specific PSU class for 7220 H4-64D """
+
+    def __init__(self, psu_index):
+        PsuBase.__init__(self)
+        # PSU is 1-based in Nokia platforms
+        self.index = psu_index + 1
+        self._fan_list = []
+        self.psu_dir = PSU_DIR[psu_index]
+
+        # PSU eeprom
+        self.eeprom = self._read_bin_file(PSU_EEPROM[psu_index], 256)
+
+    def _read_bin_file(self, sysfs_file, length):
+        """
+        On successful read, returns the value read from given
+        sysfs file and on failure returns ERR
+        """
+        rv = 'ERR'
+
+        try:
+            with open(sysfs_file, 'rb') as fd:
+                rv = fd.read(length)
+                fd.close()
+        except FileNotFoundError:
+            print(f"Error: {sysfs_file} doesn't exist.")
+        except PermissionError:
+            print(f"Error: Permission denied when reading file {sysfs_file}.")
+        except IOError:
+            print(f"IOError: An error occurred while reading file {sysfs_file}.")
+        return rv
+
+    def _get_active_psus(self):
+        """
+        Retrieves the operational status of the PSU and
+        calculates number of active PSU's
+
+        Returns:
+            Integer: Number of active PSU's
+        """
+        active_psus = 0
+
+        for i in range(PSU_NUM):
+            result = read_sysfs_file(REG_DIR+f"psu{i+1}_pwr_ok")
+            if result == '1':
+                active_psus = active_psus + 1
+
+        return active_psus
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+
+        Returns:
+            string: The name of the device
+        """
+        return f"PSU{self.index}"
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the Power Supply Unit (PSU)
+
+        Returns:
+            bool: True if PSU is present, False if not
+        """
+        result = read_sysfs_file(REG_DIR + f"psu{self.index}_present")
+
+        if result == '0':
+            return True
+
+        return False
+
+    def get_model(self):
+        """
+        Retrieves the part number of the PSU
+
+        Returns:
+            string: Part number of PSU
+        """
+        return self.eeprom[18:30].decode()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the PSU
+
+        Returns:
+            string: Serial number of PSU
+        """
+        return self.eeprom[88:99].decode()
+
+    def get_revision(self):
+        """
+        Retrieves the HW revision of the PSU
+
+        Returns:
+            string: HW revision of PSU
+        """
+        return 'N/A'
+
+    def get_part_number(self):
+        """
+        Retrieves the part number of the PSU
+
+        Returns:
+            string: Part number of PSU
+        """
+        return self.eeprom[34:48].decode()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the PSU
+
+        Returns:
+            bool: True if PSU is operating properly, False if not
+        """
+        result = read_sysfs_file(REG_DIR+f"psu{self.index}_pwr_ok")
+
+        if result == '1':
+            return True
+
+        return False
+
+    def get_voltage(self):
+        """
+        Retrieves current PSU voltage output
+
+        Returns:
+            A float number, the output voltage in volts,
+            e.g. 12.1
+        """
+        if self.get_presence():
+            result = read_sysfs_file(self.psu_dir+"in2_input")
+            psu_voltage = (float(result))/1000
+        else:
+            psu_voltage = 0.0
+
+        return psu_voltage
+
+    def get_current(self):
+        """
+        Retrieves present electric current supplied by PSU
+
+        Returns:
+            A float number, the electric current in amperes, e.g 15.4
+        """
+        if self.get_presence():
+            result = read_sysfs_file(self.psu_dir+"curr2_input")
+            psu_current = (float(result))/1000
+        else:
+            psu_current = 0.0
+
+        return psu_current
+
+    def get_power(self):
+        """
+        Retrieves current energy supplied by PSU
+
+        Returns:
+            A float number, the power in watts, e.g. 302.6
+        """
+        if self.get_presence():
+            result = read_sysfs_file(self.psu_dir+"power1_input")
+            psu_power = (float(result))/1000000
+        else:
+            psu_power = 0.0
+
+        return psu_power
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self.index
+
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+
+        Returns:
+            A float number, the high threshold output voltage in volts,
+            e.g. 12.1
+        """
+        return MAX_VOLTAGE
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+
+        Returns:
+            A float number, the low threshold output voltage in volts,
+            e.g. 12.1
+        """
+        return MIN_VOLTAGE
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
+
+    def get_powergood_status(self):
+        """
+        Retrieves the powergood status of PSU
+        Returns:
+            A boolean, True if PSU has stablized its output voltages and
+            passed all its internal self-tests, False if not.
+        """
+        result = read_sysfs_file(REG_DIR+f"psu{self.index}_pwr_ok")
+
+        if result == '1':
+            return True
+
+        return False
+
+    def get_status_led(self):
+        """
+        Gets the state of the PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        if self.get_presence():
+            if self.get_status():
+                return self.STATUS_LED_COLOR_GREEN
+            if self.get_power() == 0.0:
+                return self.STATUS_LED_COLOR_OFF
+            return self.STATUS_LED_COLOR_RED
+        return 'N/A'
+
+    def set_status_led(self, _color):
+        """
+        Sets the state of the PSU status LED
+        Args:
+            color: A string representing the color with which to set the
+                   PSU status LED
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        return False
+
+    def get_status_master_led(self):
+        """
+        Gets the state of the front panel PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        if self.get_presence():
+            if self.get_status():
+                return self.STATUS_LED_COLOR_GREEN
+            if self.get_power() == 0.0:
+                return self.STATUS_LED_COLOR_OFF
+            return self.STATUS_LED_COLOR_AMBER
+        return 'N/A'
+
+    def set_status_master_led(self, _color):
+        """
+        Sets the state of the front panel PSU status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        return False

--- a/ixr7220h4-64d/sonic_platform/sfp.py
+++ b/ixr7220h4-64d/sonic_platform/sfp.py
@@ -1,0 +1,232 @@
+"""
+    Name: sfp.py, version: 1.0
+
+    Description: Module contains the definitions of SFP related APIs
+    for Nokia IXR 7220 H4-64D platform.
+
+    Copyright (c) 2024, Nokia
+    All rights reserved.
+"""
+try:
+    import time
+    import sys
+    from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_py_common import logger, device_info
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+QSFP_PORT_NUM = 64
+
+REG_DIR = "/sys/devices/platform/sys_fpga/"
+
+SYSLOG_IDENTIFIER = "sfp"
+sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+sonic_logger.set_min_log_priority_info()
+
+class Sfp(SfpOptoeBase):
+    """
+    Nokia IXR-7220 H4-64D Platform-specific Sfp refactor class
+    """
+    instances = []
+
+    port_to_i2c_mapping = 0
+
+    def __init__(self, index, sfp_type, eeprom_path, port_i2c_map):
+        SfpOptoeBase.__init__(self)
+
+        self.index = index
+        self.port_num = index
+        self.sfp_type = sfp_type
+
+        self.eeprom_path = eeprom_path
+        self.port_to_i2c_mapping = port_i2c_map
+        if index <= QSFP_PORT_NUM:
+            self.name = sfp_type + '_' + str(index)
+            self.port_name = sfp_type + '_' + str(index-1)
+        else:
+            self.name = sfp_type + '_' + str(index-QSFP_PORT_NUM)
+            self.port_name = sfp_type + '_' + str(index-QSFP_PORT_NUM-1)
+        self.port_to_eeprom_mapping = {}
+        self.port_to_eeprom_mapping[index] = eeprom_path
+
+        self._version_info = device_info.get_sonic_version_info()
+        self.last_presence = False
+
+        Sfp.instances.append(self)
+
+    def get_eeprom_path(self):
+        """
+        Retrieves the eeprom path
+        Returns:
+            string: eeprom path
+        """
+        return self.eeprom_path
+
+    def get_presence(self):
+        """
+        Retrieves the presence
+        Returns:
+            bool: True if is present, False if not
+        """
+        sfpstatus = read_sysfs_file(REG_DIR+f"module_present_{self.index}")
+
+        if sfpstatus == '0':
+            return True
+
+        return False
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        return self.name
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        Returns:
+            integer: The 1-based relative physical position in parent device or
+                     -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
+
+    def _get_error_code(self):
+        """
+        Get error code of the SFP module
+
+        Returns:
+            The error code
+        """
+        return NotImplementedError
+
+    def get_error_description(self):
+        """
+        Get error description
+
+        Args:
+            error_code: The error code returned by _get_error_code
+
+        Returns:
+            The error description
+        """
+        if not self.get_presence():
+            error_description = self.SFP_STATUS_UNPLUGGED
+        else:
+            error_description = self.SFP_STATUS_OK
+
+        return error_description
+
+    def get_reset_status(self):
+        """
+        Retrieves the reset status of SFP
+        Returns:
+            A Boolean, True if reset enabled, False if disabled
+        """
+        if self.index <= QSFP_PORT_NUM:
+            result = read_sysfs_file(REG_DIR+f"module_reset_{self.index}")
+            if result == '0':
+                return True
+            return False
+        return False
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        """
+        reset = self.get_reset_status()
+
+        if reset is True:
+            status = False
+        else:
+            status = True
+
+        return status
+
+    def reset(self):
+        """
+        Reset SFP.
+        Returns:
+            A boolean, True if successful, False if not
+        """
+        if not self.get_presence():
+            sys.stderr.write("Error: Module not inserted, could not reset it.\n\n")
+            return False
+        sonic_logger.log_info(f"Reseting port #{self.index}.")
+
+        result1 = 'ERR'
+        result2 = 'ERR'
+        t = 0
+
+        if self.index <= QSFP_PORT_NUM:
+            result2 = write_sysfs_file(REG_DIR+f"qsfp{self.index}_reset", '1')
+            result2 = write_sysfs_file(REG_DIR+f"module_lp_mode_{self.index}", '1')
+            result1 = write_sysfs_file(REG_DIR+f"module_reset_{self.index}", '0')
+            time.sleep(0.5)
+            while t < 10:
+                if read_sysfs_file(REG_DIR+f"qsfp{self.index}_reset") == '2':
+                    result1 = write_sysfs_file(REG_DIR+f"module_reset_{self.index}", '1')
+                    time.sleep(2)
+                    break
+                time.sleep(0.5)
+                if t == 8:                    
+                    return False
+                t = t + 1
+
+            result2 = write_sysfs_file(REG_DIR+f"qsfp{self.index}_reset", '3')
+        else:
+            return False
+
+        if result1 != 'ERR' and result2 != 'ERR':
+            return True
+
+        return False
+
+    def set_lpmode(self, lpmode):
+        """
+        Sets the lpmode (low power mode) of SFP
+        Args:
+            lpmode: A Boolean, True to enable lpmode, False to disable it
+            Note  :
+        Returns:
+            A boolean, True if lpmode is set successfully, False if not
+        """
+        result = 'ERR'
+
+        if self.index <= QSFP_PORT_NUM:
+            if lpmode:
+                result = write_sysfs_file(REG_DIR+f"module_lp_mode_{self.index}", '1')
+            else:
+                result = write_sysfs_file(REG_DIR+f"module_lp_mode_{self.index}", '0')
+
+        if result != 'ERR':
+            return True
+
+        return False
+
+    def get_lpmode(self):
+        """
+        Retrieves the lpmode (low power mode) status of this SFP
+        Returns:
+            A Boolean, True if lpmode is enabled, False if disabled
+        """
+        result = 'ERR'
+
+        if self.index <= QSFP_PORT_NUM:
+            result = read_sysfs_file(REG_DIR+f"module_lp_mode_{self.index}")
+
+        if result == '1':
+            return True
+
+        return False

--- a/ixr7220h4-64d/sonic_platform/sfp_event.py
+++ b/ixr7220h4-64d/sonic_platform/sfp_event.py
@@ -1,0 +1,121 @@
+"""
+    listen for the SFP change event and return to chassis.
+"""
+try:
+    import time
+    from sonic_py_common import logger
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+# system level event/error
+EVENT_ON_ALL_SFP = '-1'
+SYSTEM_NOT_READY = 'system_not_ready'
+SYSTEM_READY = 'system_become_ready'
+SYSTEM_FAIL = 'system_fail'
+
+# SFP PORT numbers
+QSFP_PORT_NUM = 64
+PORT_START = 1
+PORT_END = 66
+
+REG_DIR = "/sys/devices/platform/sys_fpga/"
+
+SYSLOG_IDENTIFIER = "sfp_event"
+sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+sonic_logger.set_min_log_priority_info()
+
+class SfpEvent:
+    ''' Listen to plugin/plugout cable events '''
+
+    def __init__(self):
+        self.handle = None
+        self.modprs_list = []
+
+    def initialize(self):
+        """
+        Initialize SFP
+        """
+        # Get Transceiver status
+        time.sleep(5)
+        self.modprs_list = self._get_transceiver_status()
+        sonic_logger.log_info(f"Initial SFP presence={str(self.modprs_list)}")
+        if self.modprs_list[PORT_END-2]:
+            write_sysfs_file(REG_DIR+"module_tx_disable_65", '0')
+        if self.modprs_list[PORT_END-1]:
+            write_sysfs_file(REG_DIR+"module_tx_disable_66", '0')
+
+    def deinitialize(self):
+        """
+        Deinitialize SFP
+        """
+
+    def _get_transceiver_status(self):
+        port_status = []
+        reg_value = read_sysfs_file(REG_DIR + "module_present_all")
+        bin_str = f'{int(reg_value, 16):068b}'
+        bin_str = bin_str[68:1:-1]
+        bool_list = [not bool(int(bit)) for bit in bin_str]
+        port_status.extend(bool_list)
+
+        for port in range (PORT_START, PORT_START + PORT_END):
+            if port <= QSFP_PORT_NUM:
+                if port_status[port-1]:
+                    reset_status = read_sysfs_file(REG_DIR+f"qsfp{port}_reset")
+                    if reset_status == '1':                        
+                        port_status[port-1] = False
+                        write_sysfs_file(REG_DIR+f"qsfp{port}_reset", '2')
+                    elif reset_status == '2':                        
+                        port_status[port-1] = False
+                    elif reset_status == '3':                        
+                        port_status[port-1] = True
+                        write_sysfs_file(REG_DIR+f"qsfp{port}_reset", '0')
+
+        return port_status
+
+    def check_sfp_status(self, port_change, timeout):
+        """
+        check_sfp_status called from get_change_event, this will return correct
+            status of all SFP ports if there is a change in any of them
+        """
+        start_time = time.time()
+        forever = False
+
+        if timeout == 0:
+            forever = True
+        elif timeout > 0:
+            timeout = timeout / float(1000)  # Convert to secs
+        else:
+            return False, {}
+        end_time = start_time + timeout
+
+        if start_time > end_time:
+            return False, {}  # Time wrap or possibly incorrect timeout
+
+        while timeout >= 0:
+            # Check for OIR events and return updated port_change
+            port_status = self._get_transceiver_status()
+            if port_status != self.modprs_list:
+                for i in range(PORT_END):
+                    if port_status[i] != self.modprs_list[i]:
+                        # sfp_presence is active low
+                        if port_status[i]:
+                            port_change[i+1] = '1'
+                        else:
+                            port_change[i+1] = '0'
+
+                # Update reg value
+                self.modprs_list = port_status
+                return True, port_change
+
+            if forever:
+                time.sleep(1)
+            else:
+                timeout = end_time - time.time()
+                if timeout >= 1:
+                    time.sleep(1)  # We poll at 1 second granularity
+                else:
+                    if timeout > 0:
+                        time.sleep(timeout)
+                    return True, {}
+        return False, {}

--- a/ixr7220h4-64d/sonic_platform/sysfs.py
+++ b/ixr7220h4-64d/sonic_platform/sysfs.py
@@ -1,0 +1,62 @@
+"""
+    Nokia IXR7220 sysfs functions
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the PSUs' information which are available in the platform
+"""
+
+def read_sysfs_file(sysfs_file):
+    """
+    On successful read, returns the value read from given
+    reg_name and on failure returns ERR
+    """
+    rv = 'ERR'
+
+    try:
+        with open(sysfs_file, 'r', encoding='utf-8') as fd:
+            rv = fd.read()
+            fd.close()
+    except FileNotFoundError:
+        print(f"Error: {sysfs_file} doesn't exist.")
+    except PermissionError:
+        print(f"Error: Permission denied when reading file {sysfs_file}.")
+    except IOError:
+        print(f"IOError: An error occurred while reading file {sysfs_file}.")
+    if rv != 'ERR':
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+    return rv
+
+def write_sysfs_file(sysfs_file, value):
+    """
+    On successful write, the value read will be written on
+    reg_name and on failure returns ERR
+    """
+    rv = 'ERR'
+
+    try:
+        with open(sysfs_file, 'w', encoding='utf-8') as fd:
+            rv = fd.write(value)
+            fd.close()
+    except FileNotFoundError:
+        print(f"Error: {sysfs_file} doesn't exist.")
+    except PermissionError:
+        print(f"Error: Permission denied when writing file {sysfs_file}.")
+    except IOError:
+        print(f"IOError: An error occurred while writing file {sysfs_file}.")
+
+    if rv != 'ERR':
+        # Ensure that the write operation has succeeded
+        val = read_sysfs_file(sysfs_file)
+        try:
+            expected_value = int(value)
+            if val[:2] == '0x':
+                current_value = int(val, 16)
+            else:
+                current_value = int(val)
+
+            if current_value != expected_value:
+                rv = 'ERR'
+        except ValueError:
+            rv = 'ERR'
+    return rv

--- a/ixr7220h4-64d/sonic_platform/test/README
+++ b/ixr7220h4-64d/sonic_platform/test/README
@@ -1,0 +1,1 @@
+This directory contains unit tests of the Platform API 2.0

--- a/ixr7220h4-64d/sonic_platform/test/test-chassis.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-chassis.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+try:
+    import sonic_platform.platform
+    import sonic_platform.chassis
+    import unittest
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+
+class Test1(unittest.TestCase):
+    def test_1(self):
+        print("-----------------")
+        print("Chassis Unit Test")
+        print("-----------------")
+
+        chassis = sonic_platform.platform.Platform().get_chassis()
+        print("  Chassis name: {}".format(chassis.get_name()))
+
+        print("  Chassis presence: {}".format(chassis.get_presence()))
+
+        print("  Chassis serial: {}".format(chassis.get_serial()))
+
+        print("  Chassis revision: {}".format(chassis.get_revision()))
+
+        print("  Chassis status: {}".format(chassis.get_status()))
+
+        print("  Chassis base_mac: {}".format(chassis.get_base_mac()))
+
+        print("  Chassis reboot cause: {}\n".format(chassis.get_reboot_cause()))
+
+        print("  Chassis watchdog: {}".format(chassis.get_watchdog()))
+
+        print("  Chassis num_components: {}".format(chassis.get_num_components()))
+
+        print("  Chassis all_components: {}\n".format(chassis.get_all_components()))
+
+        print("  Chassis num_modules: {}".format(chassis.get_num_modules()))
+
+        print("  Chassis all_modules: {}\n".format(chassis.get_all_modules()))
+
+        print("  Chassis num_fans: {}".format(chassis.get_num_fans()))
+
+        print("  Chassis all_fans: {}\n".format(chassis.get_all_fans()))
+
+        print("  Chassis num_psus: {}".format(chassis.get_num_psus()))
+
+        print("  Chassis all_psus: {}\n".format(chassis.get_all_psus()))
+
+        print("  Chassis num_thermals: {}".format(chassis.get_num_thermals()))
+
+        print("  Chassis all_thermals: {}\n".format(chassis.get_all_thermals()))
+
+        print("  Chassis num_sfps: {}".format(chassis.get_num_sfps()))
+
+        print("  Chassis all_sfps: {}\n".format(chassis.get_all_sfps()))
+
+        print("  Chassis eeprom: {}".format(chassis.get_eeprom()))
+
+        color_to_value = {
+            'off': '0',
+            'green': '8',
+            'amber': '1',
+            'green_blink': '2',
+            'blue': '4'
+        }
+
+        for color, value in color_to_value.items():
+            print(f"Color: {color}, Value: {value}")
+            chassis.set_status_led(color)
+            t_value = chassis.get_status_led()
+            self.assertEqual(color, t_value)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ixr7220h4-64d/sonic_platform/test/test-component.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-component.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------------")
+    print("Chassis Component Unit Test")
+    print("---------------------------")
+
+    chassis = Chassis()
+
+    for component in chassis.get_all_components():
+        print("    Name: {}".format(component.get_name()))
+        print("        Description: {}".format(component.get_description()))
+        print("        FW version: {}\n".format(component.get_firmware_version()))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220h4-64d/sonic_platform/test/test-eeprom.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-eeprom.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("------------------------")
+    print("Chassis eeprom Unit Test")
+    print("------------------------")
+
+    chassis = Chassis()
+
+    eeprom = chassis.get_eeprom()
+
+    print("    Model: {}, Service Tag: {}".format(eeprom.modelstr(),
+                                             eeprom.service_tag_str()))
+    print("    Part#: {}, Serial#: {}".format(eeprom.part_number_str(),
+                                              eeprom.serial_number_str()))
+    print("    Base MAC: {}".format(eeprom.base_mac_addr()))
+
+
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220h4-64d/sonic_platform/test/test-fan-drawer.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-fan-drawer.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+import unittest
+from sonic_platform.chassis import Chassis
+
+class Test1(unittest.TestCase):
+    def test_1(self):
+        print("---------------------------")
+        print("Chassis Fan Drawer Unit Test")
+        print("---------------------------")
+
+        chassis = Chassis()
+
+        for fan_drawer in chassis.get_all_fan_drawers():
+            if not fan_drawer.get_presence():
+                print("    Name: {} not present".format(fan_drawer.get_name()))
+            else:
+                print("    Name:", fan_drawer.get_name())
+                print("        Presence: {}, Status: {}, LED: {}".format(fan_drawer.get_presence(),
+                                                                        fan_drawer.get_status(),
+                                                                        fan_drawer.get_status_led()))
+                print("        Model: {}, Serial#: {}".format(fan_drawer.get_model(),
+                                                            fan_drawer.get_serial()))
+                print("        Part#: {}".format(fan_drawer.get_part_number()))
+                print("        Direction: {}\n".format(fan_drawer.get_direction()))
+                print("        Replaceable: {}, Index: {}\n".format(fan_drawer.is_replaceable(), fan_drawer.get_position_in_parent()))
+
+
+            for color in ['off', 'red', 'green']:
+                fan_drawer.set_status_led(color)
+                t_value = fan_drawer.get_status_led()
+                self.assertEqual(color, t_value)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ixr7220h4-64d/sonic_platform/test/test-fan.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-fan.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------")
+    print("Chassis Fan Unit Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    for fan in chassis.get_all_fans():
+        if not fan.get_presence():
+            print("    Name: {} not present".format(fan.get_name()))
+        else:
+            print("    Name:", fan.get_name())
+            print("        Presence: {}, Status: {}, LED: {}".format(fan.get_presence(),
+                                                                     fan.get_status(),
+                                                                     fan.get_status_led()))
+            print("        Model: {}, Serial#: {}".format(fan.get_model(),
+                                                          fan.get_serial()))
+            print("        Part#: {}, Service Tag: {}".format(fan.get_part_number(),
+                                                              fan.get_service_tag()))
+            fan.set_speed(80)
+            print("        Direction: {}, Speed: {}%, Target Speed: {}%\n".format(fan.get_direction(),
+                                                                                    str(fan.get_speed()),
+                                                                                    str(fan.get_target_speed())))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220h4-64d/sonic_platform/test/test-psu.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-psu.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------")
+    print("Chassis PSU Unit Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    for psu in chassis.get_all_psus():
+        if not psu.get_presence():
+            print("    Name: {} not present".format(psu.get_name()))
+        else:
+            print("    Name:", psu.get_name())
+            print("    Active num:", psu._get_active_psus())
+            print("    Master LED:", psu.get_status_master_led())
+
+            print("        Presence: {}, Status: {}, LED: {}".format(psu.get_presence(),
+                                                                     psu.get_status(),
+                                                                     psu.get_status_led()))
+            print("        Model: {}, Serial#: {}, Part#: {}".format(psu.get_model(),
+                                                                     psu.get_serial(),
+                                                                     psu.get_part_number()))
+            try:
+                current = psu.get_current()
+            except NotImplementedError:
+                current = "NA"
+            try:
+                power = psu.get_power()
+            except NotImplementedError:
+                power = "NA"
+
+            print("        Voltage: {}, Current: {}, Power: {}\n".format(psu.get_voltage(),
+                                                                         current,
+                                                                         power))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220h4-64d/sonic_platform/test/test-sfp.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-sfp.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform.chassis import Chassis
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+def main():
+    print("---------------------")
+    print("Chassis SFP Unit Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    PORT_START = 1
+    PORT_END = 34
+
+    for physical_port in range(PORT_START, PORT_END+1):
+        print(" ")
+        print(" SFP transceiver tests  PORT = ", physical_port)
+        name = chassis.get_sfp(physical_port).get_name()
+        print(" SFP transceiver tests  NAME = ", name)
+
+        presence = chassis.get_sfp(physical_port).get_presence()
+        print("TEST 1 - sfp presence       [ True ] ", physical_port, presence)
+
+        status = chassis.get_sfp(physical_port).get_reset_status()
+        print("TEST 2 - sfp reset status   [ False ] ", physical_port, status)
+
+        txdisable = chassis.get_sfp(physical_port).get_tx_disable()
+        print("TEST 3 - sfp tx_disable     [ False ] ", physical_port, txdisable)
+
+        rxlos = chassis.get_sfp(physical_port).get_rx_los()
+        print("TEST 4 - sfp status rxlos   [ False ] ", physical_port, rxlos)
+
+        txfault = chassis.get_sfp(physical_port).get_tx_fault()
+        print("TEST 5 - sfp status txfault [ False ] ", physical_port, txfault)
+
+        lpmode = chassis.get_sfp(physical_port).get_lpmode()
+        print("TEST 6 - sfp enable lpmode  [ False ] ", physical_port, lpmode)
+
+        trans_info = chassis.get_sfp(physical_port).get_transceiver_info()
+        print("TEST 7 - sfp transceiver info for port:", physical_port, trans_info)
+
+        trans_status = chassis.get_sfp(physical_port).get_transceiver_bulk_status()
+        print("TEST 8 - sfp bulk status for port:", physical_port, trans_status)
+
+        threshold = chassis.get_sfp(physical_port).get_transceiver_threshold_info()
+        print("TEST 9 - sfp bulk status for port:", physical_port, threshold)
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220h4-64d/sonic_platform/test/test-thermal.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-thermal.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+def main():
+    print("-------------------------")
+    print("Chassis Thermal Unit Test")
+    print("-------------------------")
+
+    chassis = Chassis()
+
+    for thermal in chassis.get_all_thermals():
+        if not thermal.get_presence():
+            print("    Name: {} not present".format(thermal.get_name()))
+        else:
+            print("    Name:", thermal.get_name())
+            print("        Presence: {}, Status: {}".format(thermal.get_presence(),
+                                                            thermal.get_status()))
+            print("        Model: {}, Serial#: {}".format(thermal.get_model(),
+                                                          thermal.get_serial()))
+            print("        Temperature(C): {}".format(thermal.get_temperature()))
+
+            try:
+                low_thresh = thermal.get_low_threshold()
+            except NotImplementedError:
+                low_thresh = "NA"
+            try:
+                high_thresh = thermal.get_high_threshold()
+            except NotImplementedError:
+                high_thresh = "NA"
+
+            print("        Low Threshold(C): {}, High Threshold(C): {}".format(low_thresh,
+                                                                               high_thresh))
+
+            try:
+                crit_low_thresh = thermal.get_low_critical_threshold()
+            except NotImplementedError:
+                crit_low_thresh = "NA"
+            try:
+                crit_high_thresh = thermal.get_high_critical_threshold()
+            except NotImplementedError:
+                crit_high_thresh = "NA"
+
+            print("        Crit Low Threshold(C): {}, Crit High Threshold(C): {}\n".format(crit_low_thresh,
+                                                                                           crit_high_thresh))
+
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220h4-64d/sonic_platform/test/test-watchdog.py
+++ b/ixr7220h4-64d/sonic_platform/test/test-watchdog.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------")
+    print("Chassis Watchdog Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    watchdog = chassis.get_watchdog()
+
+    print("    Armed: {}".format(watchdog.is_armed()))
+    print("    Time Left: {}".format(watchdog.get_remaining_time()))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220h4-64d/sonic_platform/thermal.py
+++ b/ixr7220h4-64d/sonic_platform/thermal.py
@@ -1,0 +1,230 @@
+"""
+    Nokia IXR7220-H4-64D
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Thermals' information which are available in the platform
+"""
+
+try:
+    import glob
+    from sonic_platform_base.thermal_base import ThermalBase
+    from sonic_py_common import logger
+    from swsscommon.swsscommon import SonicV2Connector
+    from sonic_platform.sysfs import read_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+sonic_logger = logger.Logger('thermal')
+
+THERMAL_NUM = 11
+
+class Thermal(ThermalBase):
+    """Nokia platform-specific Thermal class"""
+
+    HWMON_DIR = "/sys/bus/i2c/devices/{}/hwmon/hwmon*/"
+    I2C_DEV_LIST = ["2-0048", "2-0049", "58-004c", "57-0048", "66-004d",
+                    "65-004c", "34-0048", "42-0049", "27-0049", "27-0048"]
+    THERMAL_NAME = ["MAC Rear", "MAC Under", "UDB Front", "UDB Rear", "LDB Front",
+                    "LDB Rear", "PSU Left", "PSU Right", "FAN Left", "FAN Right", "MAC TH4"]
+    THRESHHOLD = [76.0, 76.0, 61.0, 70.0, 67.0, 67.0, 77.0, 77.0, 67.0, 67.0, 100.0]
+
+    def __init__(self, thermal_index):
+        ThermalBase.__init__(self)
+        self.index = thermal_index + 1
+        if self.index == 6:
+            self.is_fan_thermal = True
+        else:
+            self.is_fan_thermal = False
+        self.dependency = None
+        self._minimum = None
+        self._maximum = None
+        self.thermal_high_threshold_file = None
+
+        # sysfs file for crit high threshold value if supported for this sensor
+        self.thermal_high_crit_threshold_file = None
+
+        if self.index == THERMAL_NUM:    # MAC internal sensor
+            self.thermal_temperature_file = None
+        else:
+            self.device_path = glob.glob(self.HWMON_DIR.format(self.I2C_DEV_LIST[self.index - 1]))
+            # sysfs file for current temperature value
+            self.thermal_temperature_file = self.device_path[0] + "temp1_input"
+
+    def get_name(self):
+        """
+        Retrieves the name of the thermal
+
+        Returns:
+            string: The name of the thermal
+        """
+        return self.THERMAL_NAME[self.index - 1]
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the thermal
+
+        Returns:
+            bool: True if thermal is present, False if not
+        """
+        if self.dependency:
+            return self.dependency.get_presence()
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the Thermal
+
+        Returns:
+            string: Model/part number of Thermal
+        """
+        return 'NA'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the Thermal
+
+        Returns:
+            string: Serial number of Thermal
+        """
+        return 'NA'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the thermal
+
+        Returns:
+            A boolean value, True if thermal is operating properly,
+            False if not
+        """
+        if self.dependency:
+            return self.dependency.get_status()
+        return True
+
+    def get_temperature(self):
+        """
+        Retrieves current temperature reading from thermal
+
+        Returns:
+            A float number of current temperature in Celsius up to
+            nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.index == THERMAL_NUM:
+            db = SonicV2Connector()
+            db.connect(db.STATE_DB)
+            data_dict = db.get_all(db.STATE_DB, 'ASIC_TEMPERATURE_INFO')
+            thermal_temperature = float(data_dict['maximum_temperature'])
+        else:
+            thermal_temperature = read_sysfs_file(self.thermal_temperature_file)
+            if thermal_temperature != 'ERR':
+                thermal_temperature = float(thermal_temperature) / 1000
+                if self._minimum is None or self._minimum > thermal_temperature:
+                    self._minimum = thermal_temperature
+                if self._maximum is None or self._maximum < thermal_temperature:
+                    self._maximum = thermal_temperature
+            else:
+                thermal_temperature = 0
+
+        return float(f"{thermal_temperature:.3f}")
+
+    def get_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of thermal
+
+        Returns:
+            A float number, the high threshold temperature of thermal in
+            Celsius up to nearest thousandth of one degree Celsius,
+            e.g. 30.125
+        """
+        return self.THRESHHOLD[self.index-1]
+
+    def set_high_threshold(self, _temperature):
+        """
+        Sets the high threshold temperature of thermal
+
+        Args :
+            temperature: A float number up to nearest thousandth of one
+            degree Celsius, e.g. 30.125
+        Returns:
+            A boolean, True if threshold is set successfully, False if
+            not
+        """
+        # Thermal threshold values are pre-defined based on HW.
+        return False
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature of thermal
+
+        Returns:
+            A float number, the high critical threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.index == THERMAL_NUM:
+            return 103.0
+        return 80.0
+
+    def set_high_critical_threshold(self):
+        """
+        Sets the high_critical threshold temperature of thermal
+
+        Args :
+            temperature: A float number up to nearest thousandth of one
+            degree Celsius, e.g. 30.125
+        Returns:
+            A boolean, True if threshold is set successfully, False if
+            not
+        """
+        # Thermal threshold values are pre-defined based on HW.
+        return False
+
+    def get_low_threshold(self):
+        """
+        Retrieves the low threshold temperature of thermal
+        Returns:
+            A float number, the low threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        return 0.0
+
+    def set_low_threshold(self, _temperature):
+        """
+        Sets the low threshold temperature of thermal
+
+        Args :
+            temperature: A float number up to nearest thousandth of one
+            degree Celsius, e.g. 30.125
+        Returns:
+            A boolean, True if threshold is set successfully, False if
+            not
+        """
+        # Thermal threshold values are pre-defined based on HW.
+        return False
+
+    def get_minimum_recorded(self):
+        """
+        Retrieves minimum recorded temperature
+        """
+        self.get_temperature()
+        return self._minimum
+
+    def get_maximum_recorded(self):
+        """
+        Retrieves maxmum recorded temperature
+        """
+        self.get_temperature()
+        return self._maximum
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self.index
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False

--- a/ixr7220h4-64d/sonic_platform/thermal_actions.py
+++ b/ixr7220h4-64d/sonic_platform/thermal_actions.py
@@ -1,0 +1,196 @@
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_action_base import ThermalPolicyActionBase
+    from sonic_platform_base.sonic_thermal_control.thermal_json_object import thermal_json_object
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+sonic_logger = logger.Logger('thermal_actions')
+
+class SetFanSpeedAction(ThermalPolicyActionBase):
+    """
+    Base thermal action class to set speed for fans
+    """
+    # JSON field definition
+    JSON_FIELD_SPEED = 'speed'
+    JSON_FIELD_DEFAULT_SPEED = 'default_speed'
+    JSON_FIELD_THRESHOLD1_SPEED = 'threshold1_speed'
+    JSON_FIELD_THRESHOLD2_SPEED = 'threshold2_speed'
+    JSON_FIELD_HIGHTEMP_SPEED = 'hightemp_speed'
+
+    def __init__(self):
+        """
+        Constructor of SetFanSpeedAction
+        """
+        self.default_speed = 50
+        self.threshold1_speed=70
+        #self.threshold2_speed=70
+        self.hightemp_speed = 90
+        self.speed = self.default_speed
+
+    def load_from_json(self, json_obj):
+        """
+        Construct SetFanSpeedAction via JSON. JSON example:
+            {
+                "type": "fan.all.set_speed"
+                "speed": "100"
+            }
+        :param json_obj: A JSON object representing a SetFanSpeedAction action.
+        :return:
+        """
+        if SetFanSpeedAction.JSON_FIELD_SPEED in json_obj:
+            speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_SPEED])
+            if speed < 0 or speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid speed value {speed} in JSON policy file, valid value should be [0, 100]')
+            self.speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_SPEED} in JSON policy file')
+
+    @classmethod
+    def set_all_fan_speed(cls, thermal_info_dict, speed):
+        from .thermal_infos import FanInfo
+        if FanInfo.INFO_NAME in thermal_info_dict and isinstance(thermal_info_dict[FanInfo.INFO_NAME], FanInfo):
+            fan_info_obj = thermal_info_dict[FanInfo.INFO_NAME]
+            for fan in fan_info_obj.get_presence_fans():
+                fan.set_speed(int(speed))
+
+@thermal_json_object('fan.all.set_speed')
+class SetAllFanSpeedAction(SetFanSpeedAction):
+    """
+    Action to set speed for all fans
+    """
+    def execute(self, thermal_info_dict):
+        """
+        Set speed for all fans
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        SetAllFanSpeedAction.set_all_fan_speed(thermal_info_dict, self.speed)
+
+@thermal_json_object('thermal.temp_check_and_set_all_fan_speed')
+class ThermalRecoverAction(SetFanSpeedAction):
+    """
+    Action to check thermal sensor temperature change status and set speed for all fans
+    """
+    def load_from_json(self, json_obj):
+        """
+        Construct ThermalRecoverAction via JSON. JSON example:
+            {
+                "type": "thermal.temp_check_and_set_all_fan_speed"
+                "default_speed": "25",
+                "threshold1_speed": "40",
+                "threshold2_speed": "75",
+                "hightemp_speed": "100"
+            }
+        :param json_obj: A JSON object representing a ThermalRecoverAction action.
+        :return:
+        """
+        if SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED in json_obj:
+            default_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED])
+            if default_speed < 0 or default_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid default speed value {default_speed} in JSON policy file, valid value should be [0, 100]')
+            self.default_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED} in JSON policy file')
+
+        if SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED in json_obj:
+            threshold1_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED])
+            if threshold1_speed < 0 or threshold1_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid default speed value {threshold1_speed} in JSON policy file, valid value should be [0, 100]')
+            self.threshold1_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED} in JSON policy file')
+
+        if SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED in json_obj:
+            hightemp_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED])
+            if hightemp_speed < 0 or hightemp_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid hightemp speed value {hightemp_speed} in JSON policy file, valid value should be [0, 100]')
+            self.hightemp_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED} in JSON policy file')
+
+        sonic_logger.log_warning(f"ThermalRecoverAction: default: {self.default_speed}, threshold1: {self.threshold1_speed}, threshold2: {self.threshold2_speed}, hightemp: {self.hightemp_speed}")
+
+    def execute(self, thermal_info_dict):
+        """
+        Check check thermal sensor temperature change status and set speed for all fans
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        from .thermal_infos import ThermalInfo
+        if ThermalInfo.INFO_NAME in thermal_info_dict and \
+           isinstance(thermal_info_dict[ThermalInfo.INFO_NAME], ThermalInfo):
+
+            thermal_info_obj = thermal_info_dict[ThermalInfo.INFO_NAME]
+            if thermal_info_obj.is_set_fan_high_temp_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.hightemp_speed)
+            elif thermal_info_obj.is_set_fan_threshold_one_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.threshold1_speed)
+            elif thermal_info_obj.is_set_fan_default_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.default_speed)
+
+@thermal_json_object('switch.shutdown')
+class SwitchPolicyAction(ThermalPolicyActionBase):
+    """
+    Base class for thermal action. Once all thermal conditions in a thermal policy are matched,
+    all predefined thermal action will be executed.
+    """
+    def execute(self, thermal_info_dict):
+        """
+        Take action when thermal condition matches. For example, adjust speed of fan or shut
+        down the switch.
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        sonic_logger.log_warning("Alarm for temperature critical is detected, reboot Device")
+        # import os
+        # os.system('reboot')
+
+@thermal_json_object('thermal_control.control')
+class ControlThermalAlgoAction(ThermalPolicyActionBase):
+    """
+    Action to control the thermal control algorithm
+    """
+    # JSON field definition
+    JSON_FIELD_STATUS = 'status'
+
+    def __init__(self):
+        self.status = True
+
+    def load_from_json(self, json_obj):
+        """
+        Construct ControlThermalAlgoAction via JSON. JSON example:
+            {
+                "type": "thermal_control.control"
+                "status": "true"
+            }
+        :param json_obj: A JSON object representing a ControlThermalAlgoAction action.
+        :return:
+        """
+        if ControlThermalAlgoAction.JSON_FIELD_STATUS in json_obj:
+            status_str = json_obj[ControlThermalAlgoAction.JSON_FIELD_STATUS].lower()
+            if status_str == 'true':
+                self.status = True
+            elif status_str == 'false':
+                self.status = False
+            else:
+                raise ValueError(f'Invalid {ControlThermalAlgoAction.JSON_FIELD_STATUS} field value, please specify true of false')
+        else:
+            raise ValueError('ControlThermalAlgoAction '
+                             f'missing mandatory field {ControlThermalAlgoAction.JSON_FIELD_STATUS} in JSON policy file')
+
+    def execute(self, thermal_info_dict):
+        """
+        Disable thermal control algorithm
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        from .thermal_infos import ChassisInfo
+        if ChassisInfo.INFO_NAME in thermal_info_dict:
+            chassis_info_obj = thermal_info_dict[ChassisInfo.INFO_NAME]
+            chassis = chassis_info_obj.get_chassis()
+            thermal_manager = chassis.get_thermal_manager()
+            if self.status:
+                thermal_manager.start_thermal_control_algorithm()
+            else:
+                thermal_manager.stop_thermal_control_algorithm()

--- a/ixr7220h4-64d/sonic_platform/thermal_conditions.py
+++ b/ixr7220h4-64d/sonic_platform/thermal_conditions.py
@@ -1,0 +1,70 @@
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_condition_base import ThermalPolicyConditionBase
+    from sonic_platform_base.sonic_thermal_control.thermal_json_object import thermal_json_object
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+class FanCondition(ThermalPolicyConditionBase):
+    def get_fan_info(self, thermal_info_dict):
+        from .thermal_infos import FanInfo
+        if FanInfo.INFO_NAME in thermal_info_dict and isinstance(thermal_info_dict[FanInfo.INFO_NAME], FanInfo):
+            return thermal_info_dict[FanInfo.INFO_NAME]
+        return None
+
+@thermal_json_object('fan.any.absence')
+class AnyFanAbsenceCondition(FanCondition):
+    def is_match(self, thermal_info_dict):
+        fan_info_obj = self.get_fan_info(thermal_info_dict)
+        return len(fan_info_obj.get_absence_fans()) > 0 if fan_info_obj else False
+
+@thermal_json_object('fan.all.absence')
+class AllFanAbsenceCondition(FanCondition):
+    def is_match(self, thermal_info_dict):
+        fan_info_obj = self.get_fan_info(thermal_info_dict)
+        return len(fan_info_obj.get_presence_fans()) == 0 if fan_info_obj else False
+
+@thermal_json_object('fan.all.presence')
+class AllFanPresenceCondition(FanCondition):
+    def is_match(self, thermal_info_dict):
+        fan_info_obj = self.get_fan_info(thermal_info_dict)
+        return len(fan_info_obj.get_absence_fans()) == 0 if fan_info_obj else False
+
+class ThermalCondition(ThermalPolicyConditionBase):
+    def get_thermal_info(self, thermal_info_dict):
+        from .thermal_infos import ThermalInfo
+        if ThermalInfo.INFO_NAME in thermal_info_dict and isinstance(thermal_info_dict[ThermalInfo.INFO_NAME], ThermalInfo):
+            return thermal_info_dict[ThermalInfo.INFO_NAME]
+        return None
+
+@thermal_json_object('thermal.over.high_critical_threshold')
+class ThermalOverHighCriticalCondition(ThermalCondition):
+    def is_match(self, thermal_info_dict):
+        thermal_info_obj = self.get_thermal_info(thermal_info_dict)
+        if thermal_info_obj:
+            return thermal_info_obj.is_over_high_critical_threshold()
+        return False
+
+class PsuCondition(ThermalPolicyConditionBase):
+    def get_psu_info(self, thermal_info_dict):
+        from .thermal_infos import PsuInfo
+        if PsuInfo.INFO_NAME in thermal_info_dict and isinstance(thermal_info_dict[PsuInfo.INFO_NAME], PsuInfo):
+            return thermal_info_dict[PsuInfo.INFO_NAME]
+        return None
+
+@thermal_json_object('psu.any.absence')
+class AnyPsuAbsenceCondition(PsuCondition):
+    def is_match(self, thermal_info_dict):
+        psu_info_obj = self.get_psu_info(thermal_info_dict)
+        return len(psu_info_obj.get_absence_psus()) > 0 if psu_info_obj else False
+
+@thermal_json_object('psu.all.absence')
+class AllPsuAbsenceCondition(PsuCondition):
+    def is_match(self, thermal_info_dict):
+        psu_info_obj = self.get_psu_info(thermal_info_dict)
+        return len(psu_info_obj.get_presence_psus()) == 0 if psu_info_obj else False
+
+@thermal_json_object('psu.all.presence')
+class AllPsuPresenceCondition(PsuCondition):
+    def is_match(self, thermal_info_dict):
+        psu_info_obj = self.get_psu_info(thermal_info_dict)
+        return len(psu_info_obj.get_absence_psus()) == 0 if psu_info_obj else False

--- a/ixr7220h4-64d/sonic_platform/thermal_infos.py
+++ b/ixr7220h4-64d/sonic_platform/thermal_infos.py
@@ -1,0 +1,240 @@
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_info_base import ThermalPolicyInfoBase
+    from sonic_platform_base.sonic_thermal_control.thermal_json_object import thermal_json_object
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+logger = Logger()
+
+@thermal_json_object('fan_info')
+class FanInfo(ThermalPolicyInfoBase):
+    """
+    Fan information needed by thermal policy
+    """
+    # Fan information name
+    INFO_NAME = 'fan_info'
+
+    def __init__(self):
+        self._absence_fans = set()
+        self._presence_fans = set()
+        self._status_changed = False
+
+    def collect(self, chassis):
+        """
+        Collect absence and presence fans.
+        :param chassis: The chassis object
+        :return:
+        """
+        self._status_changed = False
+        for fan in chassis.get_all_fans():
+            if fan.get_presence() and fan not in self._presence_fans:
+                self._presence_fans.add(fan)
+                self._status_changed = True
+                if fan in self._absence_fans:
+                    self._absence_fans.remove(fan)
+            elif not fan.get_presence() and fan not in self._absence_fans:
+                self._absence_fans.add(fan)
+                self._status_changed = True
+                if fan in self._presence_fans:
+                    self._presence_fans.remove(fan)
+
+    def get_absence_fans(self):
+        """
+        Retrieves absence fans
+        :return: A set of absence fans
+        """
+        return self._absence_fans
+
+    def get_presence_fans(self):
+        """
+        Retrieves presence fans
+        :return: A set of presence fans
+        """
+        return self._presence_fans
+
+    def is_status_changed(self):
+        """
+        Retrieves if the status of fan information changed
+        :return: True if status changed else False
+        """
+        return self._status_changed
+
+@thermal_json_object('thermal_info')
+class ThermalInfo(ThermalPolicyInfoBase):
+    """
+    Thermal information needed by thermal policy
+    """
+    # Fan information name
+    INFO_NAME = 'thermal_info'
+
+    def __init__(self):
+        self._old_threshold_level = -1
+        self._current_threshold_level = 0
+        self._num_fan_levels = 2
+        self._high_crital_threshold = 80
+        self._level_up_threshold = [[60, 59, 51, 58, 56, 54, 60, 60, 50, 50, 75],
+                                    [77, 76, 61, 70, 67, 67, 77, 77, 67, 67, 88]]
+
+        self._level_down_threshold = [[54, 54, 44, 53, 45, 47, 55, 55, 45, 45, 68],
+                                      [65, 65, 55, 65, 62, 62, 72, 72, 65, 65, 80]]
+
+    def collect(self, chassis):
+        """
+        Collect thermal sensor temperature change status
+        :param chassis: The chassis object
+        :return:
+        """
+        self._temps = []
+        self._over_high_critical_threshold = False
+        self._set_fan_default_speed = False
+        self._set_fan_threshold_one_speed = False
+        #self._set_fan_threshold_two_speed = False
+        self._set_fan_high_temp_speed = False
+
+        # Calculate average temp within the device
+        num_of_thermals = chassis.get_num_thermals()
+        for index in range(num_of_thermals):
+            self._temps.insert(index, chassis.get_thermal(index).get_temperature())
+
+       # Find current required threshold level
+        max_level =0
+        min_level = [self._num_fan_levels for i in range(num_of_thermals)]
+        for index in range(num_of_thermals):
+            for level in range(self._num_fan_levels):
+
+                if self._temps[index]>self._level_up_threshold[level][index]:
+                    if max_level<level+1:
+                        max_level=level+1
+                if self._temps[index]<self._level_down_threshold[level][index]:
+                    if min_level[index]>level:
+                        min_level[index]=level
+
+        max_of_min_level=max(min_level)
+
+        #compare with running threshold level
+        if max_of_min_level > self._old_threshold_level:
+            max_of_min_level=self._old_threshold_level
+
+        self._current_threshold_level = max(max_of_min_level,max_level)
+
+        #set fan to max speed if one fan is down
+        for fan in chassis.get_all_fans():
+            if not fan.get_status() :
+                self._current_threshold_level = 2
+
+       # Decide fan speed based on threshold level
+        if self._current_threshold_level != self._old_threshold_level:
+            if self._current_threshold_level == 0:
+                self._set_fan_default_speed = True
+            elif self._current_threshold_level == 1:
+                self._set_fan_threshold_one_speed = True
+            elif self._current_threshold_level == 2:
+                self._set_fan_high_temp_speed = True
+
+        self._old_threshold_level=self._current_threshold_level
+
+    def is_set_fan_default_speed(self):
+        """
+        Retrieves if the temperature is warm up and over high threshold
+        :return: True if the temperature is warm up and over high threshold else False
+        """
+        return self._set_fan_default_speed
+
+    def is_set_fan_threshold_one_speed(self):
+        """
+        Retrieves if the temperature is warm up and over high threshold
+        :return: True if the temperature is warm up and over high threshold else False
+        """
+        return self._set_fan_threshold_one_speed
+
+    def is_set_fan_high_temp_speed(self):
+        """
+        Retrieves if the temperature is warm up and over high threshold
+        :return: True if the temperature is warm up and over high threshold else False
+        """
+        return self._set_fan_high_temp_speed
+
+    def is_over_high_critical_threshold(self):
+        """
+        Retrieves if the temperature is over high critical threshold
+        :return: True if the temperature is over high critical threshold else False
+        """
+        return self._over_high_critical_threshold
+
+@thermal_json_object('psu_info')
+class PsuInfo(ThermalPolicyInfoBase):
+    """
+    PSU information needed by thermal policy
+    """
+    INFO_NAME = 'psu_info'
+
+    def __init__(self):
+        self._absence_psus = set()
+        self._presence_psus = set()
+        self._status_changed = False
+
+    def collect(self, chassis):
+        """
+        Collect absence and presence PSUs.
+        :param chassis: The chassis object
+        :return:
+        """
+        self._status_changed = False
+        for psu in chassis.get_all_psus():
+            if psu.get_presence() and psu.get_powergood_status() and psu not in self._presence_psus:
+                self._presence_psus.add(psu)
+                self._status_changed = True
+                if psu in self._absence_psus:
+                    self._absence_psus.remove(psu)
+            elif (not psu.get_presence() or not psu.get_powergood_status()) and psu not in self._absence_psus:
+                self._absence_psus.add(psu)
+                self._status_changed = True
+                if psu in self._presence_psus:
+                    self._presence_psus.remove(psu)
+
+    def get_absence_psus(self):
+        """
+        Retrieves presence PSUs
+        :return: A set of absence PSUs
+        """
+        return self._absence_psus
+
+    def get_presence_psus(self):
+        """
+        Retrieves presence PSUs
+        :return: A set of presence fans
+        """
+        return self._presence_psus
+
+    def is_status_changed(self):
+        """
+        Retrieves if the status of PSU information changed
+        :return: True if status changed else False
+        """
+        return self._status_changed
+
+@thermal_json_object('chassis_info')
+class ChassisInfo(ThermalPolicyInfoBase):
+    """
+    Chassis information needed by thermal policy
+    """
+    INFO_NAME = 'chassis_info'
+
+    def __init__(self):
+        self._chassis = None
+
+    def collect(self, chassis):
+        """
+        Collect platform chassis.
+        :param chassis: The chassis object
+        :return:
+        """
+        self._chassis = chassis
+
+    def get_chassis(self):
+        """
+        Retrieves platform chassis object
+        :return: A platform chassis object.
+        """
+        return self._chassis

--- a/ixr7220h4-64d/sonic_platform/thermal_manager.py
+++ b/ixr7220h4-64d/sonic_platform/thermal_manager.py
@@ -1,0 +1,57 @@
+"""
+    Nokia IXR7220-H4-64D
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Thermal Manager which are available in the platform
+"""
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_manager_base import ThermalManagerBase
+    from .thermal_actions import *
+    from .thermal_conditions import *
+    from .thermal_infos import *
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+class ThermalManager(ThermalManagerBase):
+    """Nokia platform-specific Thermal Manager class"""
+    THERMAL_ALGORITHM_CONTROL_PATH = '/var/run/hw-management/config/suspend'
+
+    @classmethod
+    def start_thermal_control_algorithm(cls):
+        """
+        Start thermal control algorithm
+
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        cls._control_thermal_control_algorithm(False)
+
+    @classmethod
+    def stop_thermal_control_algorithm(cls):
+        """
+        Stop thermal control algorithm
+
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        cls._control_thermal_control_algorithm(True)
+
+    @classmethod
+    def _control_thermal_control_algorithm(cls, suspend):
+        """
+        Control thermal control algorithm
+
+        Args:
+            suspend: Bool, indicate suspend the algorithm or not
+
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        status = True
+        write_value = 1 if suspend else 0
+        try:
+            with open(cls.THERMAL_ALGORITHM_CONTROL_PATH, 'w') as control_file:
+                control_file.write(str(write_value))
+        except (ValueError, IOError):
+            status = False
+
+        return status

--- a/ixr7220h4-64d/sonic_platform/watchdog.py
+++ b/ixr7220h4-64d/sonic_platform/watchdog.py
@@ -1,0 +1,175 @@
+"""
+    Module contains an implementation of SONiC Platform Base API and
+    provides access to hardware watchdog
+"""
+try:
+    import os
+    import fcntl
+    import array
+    from sonic_platform_base.watchdog_base import WatchdogBase
+    from sonic_platform.sysfs import read_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+# ioctl constants
+IO_WRITE = 0x40000000
+IO_READ = 0x80000000
+IO_SIZE_INT = 0x00040000
+IO_READ_WRITE = 0xC0000000
+IO_TYPE_WATCHDOG = ord('W') << 8
+
+WDR_INT = IO_READ | IO_SIZE_INT | IO_TYPE_WATCHDOG
+WDWR_INT = IO_READ_WRITE | IO_SIZE_INT | IO_TYPE_WATCHDOG
+
+# Watchdog ioctl commands
+WDIOC_SETOPTIONS = 4 | WDR_INT
+WDIOC_KEEPALIVE = 5 | WDR_INT
+WDIOC_SETTIMEOUT = 6 | WDWR_INT
+WDIOC_GETTIMEOUT = 7 | WDR_INT
+WDIOC_SETPRETIMEOUT = 8 | WDWR_INT
+WDIOC_GETPRETIMEOUT = 9 | WDR_INT
+WDIOC_GETTIMELEFT = 10 | WDR_INT
+
+# Watchdog status constants
+WDIOS_DISABLECARD = 0x0001
+WDIOS_ENABLECARD = 0x0002
+
+# watchdog sysfs
+WD_SYSFS_PATH = "/sys/class/watchdog/watchdog0/"
+
+WD_COMMON_ERROR = -1
+
+class WatchdogImplBase(WatchdogBase):
+    """
+    Base class that implements common logic for interacting
+    with watchdog using ioctl commands
+    """
+    def __init__(self, wd_device_path):
+        """
+        Open a watchdog handle
+        @param wd_device_path Path to watchdog device
+        """
+        super().__init__()
+
+        self.watchdog=""
+        self.watchdog_path = wd_device_path
+        self.wd_state_reg = WD_SYSFS_PATH+"state"
+        self.wd_timeout_reg = WD_SYSFS_PATH+"timeout"
+        self.wd_timeleft_reg = WD_SYSFS_PATH+"timeleft"
+
+        self.timeout = self._gettimeout()
+
+    def _disablewatchdog(self):
+        """
+        Turn off the watchdog timer
+        """
+        req = array.array('h', [WDIOS_DISABLECARD])
+        fcntl.ioctl(self.watchdog, WDIOC_SETOPTIONS, req, False)
+
+    def _enablewatchdog(self):
+        """
+        Turn on the watchdog timer
+        """
+        req = array.array('h', [WDIOS_ENABLECARD])
+        fcntl.ioctl(self.watchdog, WDIOC_SETOPTIONS, req, False)
+
+    def _keepalive(self):
+        """
+        Keep alive watchdog timer
+        """
+        fcntl.ioctl(self.watchdog, WDIOC_KEEPALIVE)
+
+    def _settimeout(self, seconds):
+        """
+        Set watchdog timer timeout
+        @param seconds - timeout in seconds
+        @return is the actual set timeout
+        """
+        req = array.array('I', [seconds])
+        fcntl.ioctl(self.watchdog, WDIOC_SETTIMEOUT, req, True)
+
+        return int(req[0])
+
+    def _gettimeout(self):
+        """
+        Get watchdog timeout
+        @return watchdog timeout
+        """
+        timeout=0
+        timeout=read_sysfs_file(self.wd_timeout_reg)
+
+        return timeout
+
+    def _gettimeleft(self):
+        """
+        Get time left before watchdog timer expires
+        @return time left in seconds
+        """
+        req = array.array('I', [0])
+        fcntl.ioctl(self.watchdog, WDIOC_GETTIMELEFT, req, True)
+
+        return int(req[0])
+
+    def arm(self, seconds):
+        """
+        Implements arm WatchdogBase API
+        """
+        ret = WD_COMMON_ERROR
+        if (seconds < 0 or seconds > 340 ):
+            return ret
+
+        if not self.watchdog:
+            self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)
+        try:
+            if self.timeout != seconds:
+                self.timeout = self._settimeout(seconds)
+            if self.is_armed():
+                self._keepalive()
+            else:
+                self._enablewatchdog()
+            ret = self.timeout
+        except IOError:
+            pass
+
+        return ret
+
+    def disarm(self):
+        """
+        Implements disarm WatchdogBase API
+
+        Returns:
+            A boolean, True if watchdog is disarmed successfully, False
+            if not
+        """
+        if not self.watchdog:
+            self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)
+        try:
+            self._disablewatchdog()
+            self.timeout = 0
+        except IOError:
+            return False
+
+        return True
+
+    def is_armed(self):
+        """
+        Implements is_armed WatchdogBase API
+        """
+        status = False
+
+        state = read_sysfs_file(self.wd_state_reg)
+        if state != 'inactive':
+            status = True
+
+        return status
+
+    def get_remaining_time(self):
+        """
+        Implements get_remaining_time WatchdogBase API
+        """
+        timeleft = WD_COMMON_ERROR
+
+        if self.is_armed():
+            timeleft=read_sysfs_file(self.wd_timeleft_reg)
+
+        return int(timeleft)


### PR DESCRIPTION
### Why I did it
Add support for NOKIA 7220-IXR-H4-64D platform:

> Platform: x86_64-nokia_ixr7220_h4-r0
> HwSKU: Nokia-IXR7220-H4-64D
> ASIC: Broadcom
> Port Config: 64x400G + 2x10G

### How I did it
1.	Add platform related directory ixr7220h4-64d in platform/Broadcom/sonic-platform-modules-nokia
2.	Modified related build scripts in platform/Broadcom/sonic-platform-modules-nokia/debian
### How to verify it
1.	Make sure the sonic-buildimage is successful
2.	Run this image on x86_64-nokia_ixr7220_h4-r0 and verify all dockers are up and test basic commands like:
o show version
o show platform summary
o show platform syseeprom
o show platform fan
o show platform psustatus
o show platform firmware status
o show platform temperature
o sudo show system-health detail
o show interface status
3.	Run OC test with T1-64-lag topology and have 100% pass on platform.
