### PR TITLE
[IXR7220-D4]: Add support for IXR7220-D4 Platform

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,11 @@ Package: sonic-platform-nokia-chassis
 Architecture: amd64
 Description: placeholder for hypothetical kernel modules for platform devices
 
+Package: sonic-platform-nokia-ixr7220d4
+Architecture: amd64
+Depends:  ${misc:Depends}
+Description: kernel modules for platform devices such as qsfp, fan, psu, led
+
 Package: sonic-platform-nokia-ixr7220h3
 Architecture: amd64
 Depends:  ${misc:Depends}

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ KERNEL_SRC :=  /lib/modules/$(KVERSION)
 
 
 MOD_SRC_DIR:= $(shell pwd)
-MODULE_DIRS:= chassis ixr7220h3 ixr7220h4-32d ixr7220h5-64d ixr7220h4-64d \
+MODULE_DIRS:= chassis ixr7220d4 ixr7220h3 ixr7220h4-32d ixr7220h5-64d ixr7220h4-64d \
   ixr7220h5-64o
 MODULE_DIR := modules
 UTILS_DIR := utils
@@ -58,12 +58,12 @@ build:
 binary: binary-arch binary-indep
 	# Nothing to do
 
-binary-arch: 
+binary-arch:
 	# Nothing to do
 
 binary-indep:
 # temporary commented out
-#	dh_testdir   
+#	dh_testdir
 	dh_installdirs
 
 	# Custom package commands

--- a/debian/sonic-platform-nokia-ixr7220d4.install
+++ b/debian/sonic-platform-nokia-ixr7220d4.install
@@ -1,0 +1,3 @@
+ixr7220d4/scripts/d4_platform_init.sh usr/local/bin
+ixr7220d4/service/d4_platform_init.service etc/systemd/system
+ixr7220d4/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7220_d4-r0

--- a/debian/sonic-platform-nokia-ixr7220d4.postinst
+++ b/debian/sonic-platform-nokia-ixr7220d4.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+# postinst script for sonic-platform-nokia-IXR7220-D4
+#
+# see: dh_installdeb(1)
+
+chmod a+x /usr/local/bin/d4_platform_init.sh
+systemctl enable d4_platform_init.service
+systemctl start d4_platform_init.service

--- a/ixr7220d4/modules/Makefile
+++ b/ixr7220d4/modules/Makefile
@@ -1,0 +1,1 @@
+obj-m := d4_cpupld.o d4_cpld1.o d4_cpld2.o d4_cpld3.o fan_cpld.o acton_psu.o

--- a/ixr7220d4/modules/acton_psu.c
+++ b/ixr7220d4/modules/acton_psu.c
@@ -1,0 +1,601 @@
+/*
+ * An hwmon driver for the Accton Redundant Power Module
+ *
+ */
+
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/delay.h>
+
+#define DRIVER_DESCRIPTION_NAME "accton i2c psu driver"
+/* PMBus Protocol. */
+#define PMBUS_LITERAL_DATA_MULTIPLIER           1000
+#define PMBUS_REGISTER_VOUT_MODE                0x20
+#define PMBUS_REGISTER_STATUS_BYTE              0x78
+#define PMBUS_REGISTER_STATUS_WORD              0x79
+#define PMBUS_REGISTER_STATUS_FAN               0x81
+#define PMBUS_REGISTER_READ_VIN                 0x88
+#define PMBUS_REGISTER_READ_IIN                 0x89
+#define PMBUS_REGISTER_READ_VOUT                0x8B
+#define PMBUS_REGISTER_READ_IOUT                0x8C
+#define PMBUS_REGISTER_READ_TEMPERATURE_1       0x8D
+#define PMBUS_REGISTER_READ_TEMPERATURE_2       0x8E
+#define PMBUS_REGISTER_READ_TEMPERATURE_3       0x8F
+#define PMBUS_REGISTER_READ_FAN_SPEED_1         0x90
+#define PMBUS_REGISTER_READ_FAN_SPEED_2         0x91
+
+#define PMBUS_REGISTER_READ_FAN_CONFIG_1        0x3A
+#define PMBUS_REGISTER_FAN_COMMAND_1            0x3B
+
+#define PMBUS_REGISTER_READ_POUT                0x96
+#define PMBUS_REGISTER_READ_PIN                 0x97
+#define PMBUS_REGISTER_MFR_ID                   0x99
+#define PMBUS_REGISTER_MFR_MODEL                0x9A
+#define PMBUS_REGISTER_MFR_REVISION             0x9B
+#define PMBUS_REGISTER_MFR_SERIAL               0x9E
+
+
+#define MAX_FAN_DUTY_CYCLE      100
+#define I2C_RW_RETRY_COUNT		10
+#define I2C_RW_RETRY_INTERVAL	60 /* ms */
+
+/* Addresses scanned
+ */
+static const unsigned short normal_i2c[] = { 0x58, 0x59, I2C_CLIENT_END };
+
+/* Each client has this additional data
+ */
+struct accton_i2c_psu_data {
+    struct device      *hwmon_dev;
+    struct mutex        update_lock;
+    char                valid;           /* !=0 if registers are valid */
+    unsigned long       last_updated;    /* In jiffies */
+    u8   vout_mode;     /* Register value */
+    u16  v_in;          /* Register value */
+    u16  v_out;         /* Register value */
+    u16  i_in;          /* Register value */
+    u16  i_out;         /* Register value */
+    u16  p_in;          /* Register value */
+    u16  p_out;         /* Register value */
+    u16  temp_input[2]; /* Register value */
+    u8   fan_fault;     /* Register value */
+    u16  fan_duty_cycle[2];  /* Register value */
+    u16  fan_speed[2];  /* Register value */
+    u8   pmbus_revision; /* Register value */
+    u8   mfr_id[10];	 /* Register value */
+	u8   mfr_model[16]; /* Register value */
+	u8   mfr_revsion[3]; /* Register value */
+	u8   mfr_serial[26]; /* Register value */
+};
+
+static ssize_t show_linear(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t show_fan_fault(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t show_vout(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t set_fan_duty_cycle(struct device *dev, struct device_attribute *da, const char *buf, size_t count);
+static ssize_t show_ascii(struct device *dev, struct device_attribute *da,
+			 char *buf);
+static ssize_t show_byte(struct device *dev, struct device_attribute *da,
+			 char *buf);
+
+static int accton_i2c_psu_write_word(struct i2c_client *client, u8 reg, u16 value);
+static struct accton_i2c_psu_data *accton_i2c_psu_update_device(struct device *dev);
+
+enum accton_i2c_psu_sysfs_attributes {
+    PSU_V_IN,
+    PSU_V_OUT,
+    PSU_I_IN,
+    PSU_I_OUT,
+    PSU_P_IN,
+    PSU_P_OUT_UV,
+    PSU_P_OUT,
+    PSU_TEMP1_INPUT,
+    PSU_FAN1_FAULT,
+    PSU_FAN1_DUTY_CYCLE,
+    PSU_FAN1_SPEED,
+    PSU_PMBUS_REVISION,
+	PSU_MFR_ID,
+	PSU_MFR_MODEL,
+	PSU_MFR_REVISION,
+	PSU_MFR_SERIAL,
+};
+
+/* sysfs attributes for hwmon
+ */
+static SENSOR_DEVICE_ATTR(psu_v_in,        S_IRUGO, show_linear,      NULL, PSU_V_IN);
+static SENSOR_DEVICE_ATTR(psu_v_out,       S_IRUGO, show_vout,        NULL, PSU_V_OUT);
+static SENSOR_DEVICE_ATTR(psu_i_in,        S_IRUGO, show_linear,      NULL, PSU_I_IN);
+static SENSOR_DEVICE_ATTR(psu_i_out,       S_IRUGO, show_linear,      NULL, PSU_I_OUT);
+static SENSOR_DEVICE_ATTR(psu_p_in,        S_IRUGO, show_linear,      NULL, PSU_P_IN);
+static SENSOR_DEVICE_ATTR(psu_p_out,       S_IRUGO, show_linear,      NULL, PSU_P_OUT);
+static SENSOR_DEVICE_ATTR(psu_temp1_input, S_IRUGO, show_linear,      NULL, PSU_TEMP1_INPUT);
+static SENSOR_DEVICE_ATTR(psu_fan1_fault,  S_IRUGO, show_fan_fault,   NULL, PSU_FAN1_FAULT);
+static SENSOR_DEVICE_ATTR(psu_fan1_duty_cycle_percentage, S_IWUSR | S_IRUGO, show_linear, set_fan_duty_cycle, PSU_FAN1_DUTY_CYCLE);
+static SENSOR_DEVICE_ATTR(psu_fan1_speed_rpm, S_IRUGO, show_linear,   NULL, PSU_FAN1_SPEED);
+static SENSOR_DEVICE_ATTR(psu_pmbus_revision,S_IRUGO, show_byte,   NULL, PSU_PMBUS_REVISION);
+static SENSOR_DEVICE_ATTR(psu_mfr_id,		S_IRUGO, show_ascii,  NULL, PSU_MFR_ID);
+static SENSOR_DEVICE_ATTR(psu_mfr_model,	S_IRUGO, show_ascii,  NULL, PSU_MFR_MODEL);
+static SENSOR_DEVICE_ATTR(psu_mfr_revision,	S_IRUGO, show_ascii, NULL, PSU_MFR_REVISION);
+static SENSOR_DEVICE_ATTR(psu_mfr_serial,	S_IRUGO, show_ascii, NULL, PSU_MFR_SERIAL);
+
+
+/*Duplicate nodes for lm-sensors.*/
+static SENSOR_DEVICE_ATTR(in3_input, S_IRUGO, show_vout,    NULL, PSU_V_OUT);
+static SENSOR_DEVICE_ATTR(curr2_input, S_IRUGO, show_linear,    NULL, PSU_I_OUT);
+static SENSOR_DEVICE_ATTR(power2_input, S_IRUGO, show_linear,    NULL, PSU_P_OUT_UV);
+static SENSOR_DEVICE_ATTR(temp1_input, S_IRUGO, show_linear,    NULL, PSU_TEMP1_INPUT);
+static SENSOR_DEVICE_ATTR(fan1_input, S_IRUGO, show_linear, NULL, PSU_FAN1_SPEED);
+//static SENSOR_DEVICE_ATTR(temp1_fault,  S_IRUGO, show_word,      NULL, PSU_TEMP_FAULT);
+
+
+static struct attribute *accton_i2c_psu_attributes[] = {
+    &sensor_dev_attr_psu_v_in.dev_attr.attr,
+    &sensor_dev_attr_psu_v_out.dev_attr.attr,
+    &sensor_dev_attr_psu_i_in.dev_attr.attr,
+    &sensor_dev_attr_psu_i_out.dev_attr.attr,
+    &sensor_dev_attr_psu_p_in.dev_attr.attr,
+    &sensor_dev_attr_psu_p_out.dev_attr.attr,
+    &sensor_dev_attr_psu_temp1_input.dev_attr.attr,
+    &sensor_dev_attr_psu_fan1_fault.dev_attr.attr,
+    &sensor_dev_attr_psu_fan1_duty_cycle_percentage.dev_attr.attr,
+    &sensor_dev_attr_psu_fan1_speed_rpm.dev_attr.attr,
+    &sensor_dev_attr_psu_pmbus_revision.dev_attr.attr,
+    &sensor_dev_attr_psu_mfr_id.dev_attr.attr,
+    &sensor_dev_attr_psu_mfr_model.dev_attr.attr,
+    &sensor_dev_attr_psu_mfr_revision.dev_attr.attr,
+    &sensor_dev_attr_psu_mfr_serial.dev_attr.attr,
+     /*Duplicate nodes for lm-sensors.*/
+    &sensor_dev_attr_curr2_input.dev_attr.attr,
+    &sensor_dev_attr_in3_input.dev_attr.attr,
+    &sensor_dev_attr_power2_input.dev_attr.attr,
+    &sensor_dev_attr_temp1_input.dev_attr.attr,
+    &sensor_dev_attr_fan1_input.dev_attr.attr,
+    //&sensor_dev_attr_temp1_fault.dev_attr.attr,
+    NULL
+};
+
+static int two_complement_to_int(u16 data, u8 valid_bit, int mask)
+{
+    u16  valid_data  = data & mask;
+    bool is_negative = valid_data >> (valid_bit - 1);
+
+    return is_negative ? (-(((~valid_data) & mask) + 1)) : valid_data;
+}
+
+static ssize_t set_fan_duty_cycle(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct accton_i2c_psu_data *data = i2c_get_clientdata(client);
+    int nr = (attr->index == PSU_FAN1_DUTY_CYCLE) ? 0 : 1;
+	long speed;
+	int error;
+
+	error = kstrtol(buf, 10, &speed);
+	if (error)
+		return error;
+
+    if (speed < 0 || speed > MAX_FAN_DUTY_CYCLE)
+        return -EINVAL;
+
+    mutex_lock(&data->update_lock);
+    data->fan_duty_cycle[nr] = speed;
+    accton_i2c_psu_write_word(client, PMBUS_REGISTER_FAN_COMMAND_1 + nr, data->fan_duty_cycle[nr]);
+    mutex_unlock(&data->update_lock);
+
+    return count;
+}
+
+static ssize_t show_linear(struct device *dev, struct device_attribute *da,
+             char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct accton_i2c_psu_data *data = accton_i2c_psu_update_device(dev);
+
+    u16 value = 0;
+    int exponent, mantissa;
+    int multiplier = 0;
+
+    switch (attr->index) {
+    case PSU_V_IN:
+        value = data->v_in;
+        break;
+    case PSU_I_IN:
+        value = data->i_in;
+        break;
+    case PSU_I_OUT:
+        value = data->i_out;
+        break;
+    case PSU_P_IN:
+        value = data->p_in;
+        break;
+    case PSU_P_OUT_UV:
+        multiplier=1;
+    case PSU_P_OUT:
+        value = data->p_out;
+        break;
+    case PSU_TEMP1_INPUT:
+        value = data->temp_input[0];
+        break;
+    case PSU_FAN1_DUTY_CYCLE:
+        multiplier = 1;
+        value = data->fan_duty_cycle[0];
+        break;
+    case PSU_FAN1_SPEED:
+        multiplier = 1;
+        value = data->fan_speed[0];
+        break;
+    default:
+        break;
+    }
+
+    exponent = two_complement_to_int(value >> 11, 5, 0x1f);
+    mantissa = two_complement_to_int(value & 0x7ff, 11, 0x7ff);
+
+    if(!multiplier)
+        multiplier = PMBUS_LITERAL_DATA_MULTIPLIER;
+    if(attr->index==PSU_P_OUT_UV)
+        multiplier = 1000000;
+
+    return (exponent >= 0) ? sprintf(buf, "%d\n", (mantissa << exponent) * multiplier) :
+                             sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));
+}
+
+static ssize_t show_fan_fault(struct device *dev, struct device_attribute *da,
+             char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct accton_i2c_psu_data *data = accton_i2c_psu_update_device(dev);
+
+    u8 shift = (attr->index == PSU_FAN1_FAULT) ? 7 : 6;
+
+    return sprintf(buf, "%d\n", data->fan_fault >> shift);
+}
+
+static ssize_t show_vout(struct device *dev, struct device_attribute *da,
+             char *buf)
+{
+    struct accton_i2c_psu_data *data = accton_i2c_psu_update_device(dev);
+    int exponent, mantissa;
+
+    exponent = two_complement_to_int(data->vout_mode, 5, 0x1f);
+    mantissa = data->v_out;
+
+    return (exponent > 0) ? sprintf(buf, "%d\n", (mantissa << exponent) * PMBUS_LITERAL_DATA_MULTIPLIER) :
+                            sprintf(buf, "%d\n", (mantissa * PMBUS_LITERAL_DATA_MULTIPLIER) / (1 << -exponent));
+}
+
+static ssize_t show_byte(struct device *dev, struct device_attribute *da,
+			 char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct accton_i2c_psu_data *data = accton_i2c_psu_update_device(dev);
+
+	if (!data->valid) {
+		return 0;
+	}
+
+	return (attr->index == PSU_PMBUS_REVISION) ? sprintf(buf, "%d\n", data->pmbus_revision) :
+								 sprintf(buf, "0\n");
+}
+
+static ssize_t show_ascii(struct device *dev, struct device_attribute *da,
+			 char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct accton_i2c_psu_data *data = accton_i2c_psu_update_device(dev);
+	u8 *ptr = NULL;
+
+	if (!data->valid) {
+		return 0;
+	}
+	switch (attr->index) {
+
+	case PSU_MFR_ID:
+			ptr = data->mfr_id;
+		break;
+	case PSU_MFR_MODEL:
+			ptr = data->mfr_model;
+		break;
+	case PSU_MFR_REVISION:
+			ptr = data->mfr_revsion;
+		break;
+	case PSU_MFR_SERIAL:
+		ptr = data->mfr_serial;
+		break;
+	default:
+		return 0;
+	}
+
+	return sprintf(buf, "%s\n", ptr);
+}
+
+
+static const struct attribute_group accton_i2c_psu_group = {
+    .attrs = accton_i2c_psu_attributes,
+};
+
+static int accton_i2c_psu_probe(struct i2c_client *client,
+            const struct i2c_device_id *dev_id)
+{
+    struct accton_i2c_psu_data *data;
+    int status;
+
+    if (!i2c_check_functionality(client->adapter,
+        I2C_FUNC_SMBUS_BYTE_DATA | I2C_FUNC_SMBUS_WORD_DATA)) {
+        status = -EIO;
+        goto exit;
+    }
+
+    data = kzalloc(sizeof(struct accton_i2c_psu_data), GFP_KERNEL);
+    if (!data) {
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    i2c_set_clientdata(client, data);
+    data->valid = 0;
+    mutex_init(&data->update_lock);
+
+    dev_info(&client->dev, "chip found\n");
+
+    /* Register sysfs hooks */
+    status = sysfs_create_group(&client->dev.kobj, &accton_i2c_psu_group);
+    if (status) {
+        goto exit_free;
+    }
+
+    data->hwmon_dev = hwmon_device_register(&client->dev);
+    if (IS_ERR(data->hwmon_dev)) {
+        status = PTR_ERR(data->hwmon_dev);
+        goto exit_remove;
+    }
+
+    dev_info(&client->dev, "%s: psu '%s'\n",
+         dev_name(data->hwmon_dev), client->name);
+
+    return 0;
+
+exit_remove:
+    sysfs_remove_group(&client->dev.kobj, &accton_i2c_psu_group);
+exit_free:
+    kfree(data);
+exit:
+
+    return status;
+}
+
+static void accton_i2c_psu_remove(struct i2c_client *client)
+{
+    struct accton_i2c_psu_data *data = i2c_get_clientdata(client);
+
+    hwmon_device_unregister(data->hwmon_dev);
+    sysfs_remove_group(&client->dev.kobj, &accton_i2c_psu_group);
+    kfree(data);
+
+}
+/* Support psu moduel
+ */
+static const struct i2c_device_id accton_i2c_psu_id[] = {
+    { "acbel_fsh082", 0 },
+    { "yesm1300am", 1 },
+    {}
+};
+MODULE_DEVICE_TABLE(i2c, accton_i2c_psu_id);
+
+static struct i2c_driver accton_i2c_psu_driver = {
+    .class        = I2C_CLASS_HWMON,
+    .driver = {
+        .name     = "accton_i2c_psu",
+    },
+    .probe        = accton_i2c_psu_probe,
+    .remove       = accton_i2c_psu_remove,
+    .id_table     = accton_i2c_psu_id,
+    .address_list = normal_i2c,
+};
+
+static int accton_i2c_psu_read_byte(struct i2c_client *client, u8 reg)
+{
+    return i2c_smbus_read_byte_data(client, reg);
+}
+
+static int accton_i2c_psu_read_word(struct i2c_client *client, u8 reg)
+{
+    return i2c_smbus_read_word_data(client, reg);
+}
+
+static int accton_i2c_psu_write_word(struct i2c_client *client, u8 reg, u16 value)
+{
+    return i2c_smbus_write_word_data(client, reg, value);
+}
+
+static int accton_i2c_psu_read_block(struct i2c_client *client, u8 command, u8 *data,
+			  int data_len)
+{
+	int status = 0, retry = I2C_RW_RETRY_COUNT;
+
+	while (retry) {
+		status = i2c_smbus_read_i2c_block_data(client, command, data_len, data);
+		if (unlikely(status < 0)) {
+			msleep(I2C_RW_RETRY_INTERVAL);
+			retry--;
+			continue;
+		}
+
+		break;
+	}
+
+    return status;
+}
+
+
+static int accton_i2c_psu_read_block_data(struct i2c_client *client, u8 command, u8 *data, int data_length)
+{
+    int status = -EIO;
+    int length;
+    u8 buffer[128] = {0}, *ptr = buffer;
+
+    status = accton_i2c_psu_read_byte(client, command);
+    if (status < 0)
+    {
+        dev_dbg(&client->dev, "Unable to get data from offset 0x%02X\r\n", command);
+        status = -EIO;
+        goto EXIT_READ_BLOCK_DATA;
+    }
+
+    status = (status & 0xFF) + 1;
+    if ( status > 128)
+    {
+        dev_dbg(&client->dev, "Unable to get big data from offset 0x%02X\r\n", command);
+        status = -EINVAL;
+        goto EXIT_READ_BLOCK_DATA;
+    }
+
+    length = status;
+    status = accton_i2c_psu_read_block(client, command, buffer, length);
+    if (unlikely(status < 0))
+        goto EXIT_READ_BLOCK_DATA;
+    if (unlikely(status != length)) {
+        status = -EIO;
+        goto EXIT_READ_BLOCK_DATA;
+    }
+    /* The first byte is the count byte of string. */
+    ptr++;
+    status--;
+
+    length=status>(data_length-1)?(data_length-1):status;
+    memcpy(data, ptr, length);
+    data[length-1] = 0;
+
+EXIT_READ_BLOCK_DATA:
+
+    return status;
+}
+
+
+struct reg_data_byte {
+    u8   reg;
+    u8  *value;
+};
+
+struct reg_data_word {
+    u8   reg;
+    u16 *value;
+};
+
+static struct accton_i2c_psu_data *accton_i2c_psu_update_device(struct device *dev)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct accton_i2c_psu_data *data = i2c_get_clientdata(client);
+
+    mutex_lock(&data->update_lock);
+
+    if (time_after(jiffies, data->last_updated + HZ + HZ / 2)
+        || !data->valid) {
+        int i, status;
+        //u8 command, buf;
+        struct reg_data_byte regs_byte[] = { {PMBUS_REGISTER_VOUT_MODE, &data->vout_mode},
+                                             {PMBUS_REGISTER_STATUS_FAN, &data->fan_fault}};
+        struct reg_data_word regs_word[] = { {PMBUS_REGISTER_READ_VIN, &data->v_in},
+                                             {PMBUS_REGISTER_READ_VOUT, &data->v_out},
+                                             {PMBUS_REGISTER_READ_IIN, &data->i_in},
+                                             {PMBUS_REGISTER_READ_IOUT, &data->i_out},
+                                             {PMBUS_REGISTER_READ_POUT, &data->p_out},
+                                             {PMBUS_REGISTER_READ_PIN, &data->p_in},
+                                             {PMBUS_REGISTER_READ_TEMPERATURE_1, &(data->temp_input[0])},
+                                             {PMBUS_REGISTER_READ_TEMPERATURE_2, &(data->temp_input[1])},
+                                             {PMBUS_REGISTER_FAN_COMMAND_1, &(data->fan_duty_cycle[0])},
+                                             {PMBUS_REGISTER_READ_FAN_SPEED_1, &(data->fan_speed[0])},
+                                             {PMBUS_REGISTER_READ_FAN_SPEED_2, &(data->fan_speed[1])},
+                                             };
+
+        dev_dbg(&client->dev, "Starting accton_i2c_psu update\n");
+
+        /* Read byte data */
+        for (i = 0; i < ARRAY_SIZE(regs_byte); i++) {
+            status = accton_i2c_psu_read_byte(client, regs_byte[i].reg);
+
+            if (status < 0) {
+                dev_dbg(&client->dev, "reg %d, err %d\n",
+                        regs_byte[i].reg, status);
+            }
+            else {
+                *(regs_byte[i].value) = status;
+            }
+        }
+
+        /* Read word data */
+        for (i = 0; i < ARRAY_SIZE(regs_word); i++) {
+            status = accton_i2c_psu_read_word(client, regs_word[i].reg);
+
+            if (status < 0) {
+                dev_dbg(&client->dev, "reg %d, err %d\n",
+                        regs_word[i].reg, status);
+            }
+            else {
+                *(regs_word[i].value) = status;
+            }
+
+        }
+        /* Read mfr_id */
+		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_ID, data->mfr_id,
+										 ARRAY_SIZE(data->mfr_id));
+		if (status < 0) {
+			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_ID, status);
+			goto exit;
+		}
+		/* Read mfr_model */
+		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_MODEL, data->mfr_model,
+										 ARRAY_SIZE(data->mfr_model));
+		if (status < 0) {
+			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_MODEL, status);
+			goto exit;
+		}
+        /* Read mfr_revsion */
+		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_REVISION, data->mfr_revsion,
+										 ARRAY_SIZE(data->mfr_revsion));
+		if (status < 0) {
+			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_REVISION, status);
+			goto exit;
+		}
+		/* Read mfr_serial */
+		status = accton_i2c_psu_read_block_data(client, PMBUS_REGISTER_MFR_SERIAL, data->mfr_serial,
+										 ARRAY_SIZE(data->mfr_serial));
+		if (status < 0) {
+			dev_dbg(&client->dev, "reg %d, err %d\n", PMBUS_REGISTER_MFR_SERIAL, status);
+			goto exit;
+		}
+
+        data->last_updated = jiffies;
+        data->valid = 1;
+    }
+
+exit:
+    mutex_unlock(&data->update_lock);
+
+    return data;
+}
+
+static int __init accton_i2c_psu_init(void)
+{
+    return i2c_add_driver(&accton_i2c_psu_driver);
+}
+
+static void __exit accton_i2c_psu_exit(void)
+{
+    i2c_del_driver(&accton_i2c_psu_driver);
+}
+
+
+MODULE_DESCRIPTION(DRIVER_DESCRIPTION_NAME);
+MODULE_LICENSE("GPL");
+
+module_init(accton_i2c_psu_init);
+module_exit(accton_i2c_psu_exit);

--- a/ixr7220d4/modules/d4_cpld1.c
+++ b/ixr7220d4/modules/d4_cpld1.c
@@ -1,0 +1,1000 @@
+//  * CPLD driver for Nokia-7220-IXR-D4
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  *
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+#include <linux/delay.h>
+
+#define DRIVER_NAME "d4_cpld1"
+
+// REGISTERS ADDRESS MAP
+#define BOARD_INFO_REG          0x00
+#define CPLD1_VER_REG           0x01
+#define POWER_STATUS_REG1       0x02
+#define POWER_STATUS_REG2       0x03
+
+#define SYSTEM_RST_REG1         0x04
+#define SYSTEM_RST_REG2         0x05
+#define SYSTEM_RST_REG3         0x06
+#define SYSTEM_RST_REG4         0x07
+#define SYSTEM_RST_REG5         0x08
+#define SYSTEM_RST_REG6         0x09
+
+#define MOD_PRSNT_REG1          0x1F
+#define MOD_PRSNT_REG2          0x20
+#define MOD_PRSNT_REG3          0x21
+#define MOD_PRSNT_REG4          0x22
+#define MOD_PRSNT_REG5          0x23
+#define SYSTEM_LED_REG1         0x59
+#define SYSTEM_LED_REG2         0x60
+
+// REG BIT FIELD POSITION or MASK
+#define BOARD_INFO_REG_PCB_VER_MSK            0x3
+
+#define PS1_PRESENT            0x0
+#define PS2_PRESENT            0x1
+#define PS1_PW_OK              0x2
+#define PS2_PW_OK              0x3
+#define PS1_ACDC_I_OK          0x4
+#define PS2_ACDC_I_OK          0x5
+
+#define PS1_POWER_ON           0x0
+#define PS2_POWER_ON           0x1
+
+#define I2C_SW1_RST            0x0
+#define I2C_SW2_RST            0x1
+#define I2C_SW3_RST            0x2
+#define I2C_SW4_RST            0x3
+#define I2C_SW5_RST            0x4
+#define I2C_SW6_RST            0x5
+#define I2C_SW7_RST            0x6
+
+#define PSU1_LED_MASK          0x0
+#define PSU2_LED_MASK          0x2
+#define FAN_LED_MASK           0x4
+#define SYSTEM_LED_MASK        0x4
+
+static const unsigned short cpld1_address_list[] = {0x60, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int reset_list[36];
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+/* ---------------- */
+
+static void dump_reg(struct cpld_data *data)
+{
+    struct i2c_client *client = data->client;
+    u8 val0 = 0;
+    u8 val1 = 0;
+    u8 val2 = 0;
+    u8 val3 = 0;
+    u8 val4 = 0;
+
+    val0 = cpld_i2c_read(data, SYSTEM_RST_REG1);
+    val1 = cpld_i2c_read(data, SYSTEM_RST_REG2);
+    val2 = cpld_i2c_read(data, SYSTEM_RST_REG3);
+    val3 = cpld_i2c_read(data, SYSTEM_RST_REG4);
+    val4 = cpld_i2c_read(data, SYSTEM_RST_REG5);
+    dev_info(&client->dev, "[CPLD1]QSFP_RESET_REG: 0x%02x, 0x%02x, 0x%02x,"
+                           "0x%02x, 0x%02x\n",
+                           val0, val1, val2, val3, val4);
+}
+
+/* ---------------- */
+
+static ssize_t show_pcb_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    char *str_ver = NULL;
+    u8 val = 0;
+    val = cpld_i2c_read(data, BOARD_INFO_REG) & BOARD_INFO_REG_PCB_VER_MSK;
+
+    switch (val) {
+    case 0x0:
+        str_ver = "R0A";
+        break;
+    case 0x1:
+        str_ver = "R0B";
+        break;
+    case 0x2:
+        str_ver = "R01";
+        break;
+    default:
+        str_ver = "Reserved";
+        break;
+    }
+
+    return sprintf(buf, "0x%x %s\n", val, str_ver);
+}
+
+/* ---------------- */
+
+static ssize_t show_cpld_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, CPLD1_VER_REG);
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+/* ---------------- */
+
+static ssize_t show_power_module1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, POWER_STATUS_REG1);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_power_module2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, POWER_STATUS_REG2);
+
+    /* If the bit is set, power supply is disabled. */
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_power_module2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, POWER_STATUS_REG2);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, POWER_STATUS_REG2, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_system_rst1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_RST_REG1);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_system_rst1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG1);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_RST_REG1, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_system_rst2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_RST_REG2);
+
+    /* If the bit is set, power supply is disabled. */
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_system_rst2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG2);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_RST_REG2, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_system_rst3(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_RST_REG3);
+
+    /* If the bit is set, power supply is disabled. */
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_system_rst3(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG3);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_RST_REG3, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_system_rst4(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_RST_REG4);
+
+    /* If the bit is set, power supply is disabled. */
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_system_rst4(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG4);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_RST_REG4, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_system_rst5(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_RST_REG5);
+
+    /* If the bit is set, power supply is disabled. */
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_system_rst5(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG5);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_RST_REG5, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_system_rst6(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_RST_REG6);
+
+    /* If the bit is set, power supply is disabled. */
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_system_rst6(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG6);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_RST_REG6, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_module_prsnt1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, MOD_PRSNT_REG1);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_module_prsnt2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, MOD_PRSNT_REG2);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_module_prsnt3(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, MOD_PRSNT_REG3);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_module_prsnt4(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, MOD_PRSNT_REG4);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_module_prsnt5(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, MOD_PRSNT_REG5);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_system_led1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_LED_REG1);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x3);
+}
+
+static ssize_t set_system_led1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 3) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x3 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_LED_REG1);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_LED_REG1, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_system_led2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_LED_REG2);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0xF);
+}
+
+static ssize_t set_system_led2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 15) {
+        return -EINVAL;
+    }
+
+    mask = (~(0xF << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_LED_REG2);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, SYSTEM_LED_REG2, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_qsfp_reset(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+
+    return sprintf(buf, "%d\n", data->reset_list[sda->index]);
+}
+
+static ssize_t set_qsfp_reset(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 0xFF) {
+        return -EINVAL;
+    }
+
+    data->reset_list[sda->index] = usr_val;
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t set_bulk_qsfp_reset(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 usr_val = 0, reg_val = 0;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG4);
+    switch(usr_val){
+        case 0:
+            cpld_i2c_write(data, SYSTEM_RST_REG1, 0x00);
+            cpld_i2c_write(data, SYSTEM_RST_REG2, 0x00);
+            cpld_i2c_write(data, SYSTEM_RST_REG3, 0x00);
+            cpld_i2c_write(data, SYSTEM_RST_REG4, reg_val & 0xF0);
+            cpld_i2c_write(data, SYSTEM_RST_REG5, 0x00);
+            break;
+        case 1:
+            cpld_i2c_write(data, SYSTEM_RST_REG1, 0xFF);
+            cpld_i2c_write(data, SYSTEM_RST_REG2, 0xFF);
+            cpld_i2c_write(data, SYSTEM_RST_REG3, 0xFF);
+            cpld_i2c_write(data, SYSTEM_RST_REG4, reg_val | 0x0F);
+            cpld_i2c_write(data, SYSTEM_RST_REG5, 0xFF);
+            for (int i=0;i<36;i++) data->reset_list[i] = 0;
+    }
+    dump_reg(data);
+    return count;
+}
+
+static ssize_t show_bulk_qsfp_reset(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+
+    u8 val0 = 0;
+    u8 val1 = 0;
+    u8 val2 = 0;
+    u8 val3 = 0;
+    u8 val4 = 0;
+
+    val0 = cpld_i2c_read(data, SYSTEM_RST_REG1);
+    val1 = cpld_i2c_read(data, SYSTEM_RST_REG2);
+    val2 = cpld_i2c_read(data, SYSTEM_RST_REG3);
+    val3 = cpld_i2c_read(data, SYSTEM_RST_REG4);
+    val4 = cpld_i2c_read(data, SYSTEM_RST_REG5);
+
+    return sprintf(buf, "%d %d %d %d %d\n", val0, val1, val2, val3, val4);
+}
+
+// sysfs attributes
+static SENSOR_DEVICE_ATTR(pcb_ver, S_IRUGO, show_pcb_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(cpld_ver, S_IRUGO, show_cpld_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(psu1_present, S_IRUGO, show_power_module1, NULL, PS1_PRESENT);
+static SENSOR_DEVICE_ATTR(psu2_present, S_IRUGO, show_power_module1, NULL, PS2_PRESENT);
+static SENSOR_DEVICE_ATTR(psu1_pwr_ok, S_IRUGO, show_power_module1, NULL, PS1_PW_OK);
+static SENSOR_DEVICE_ATTR(psu2_pwr_ok, S_IRUGO, show_power_module1, NULL, PS2_PW_OK);
+static SENSOR_DEVICE_ATTR(psu1_input_ok, S_IRUGO, show_power_module1, NULL, PS1_ACDC_I_OK);
+static SENSOR_DEVICE_ATTR(psu2_input_ok, S_IRUGO, show_power_module1, NULL, PS2_ACDC_I_OK);
+static SENSOR_DEVICE_ATTR(psu1_power_ok, S_IRUGO | S_IWUSR, show_power_module2, set_power_module2, PS1_POWER_ON);
+static SENSOR_DEVICE_ATTR(psu2_power_ok, S_IRUGO | S_IWUSR, show_power_module2, set_power_module2, PS2_POWER_ON);
+static SENSOR_DEVICE_ATTR(qsfp1_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 0);
+static SENSOR_DEVICE_ATTR(qsfp2_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 1);
+static SENSOR_DEVICE_ATTR(qsfp3_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 2);
+static SENSOR_DEVICE_ATTR(qsfp4_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 3);
+static SENSOR_DEVICE_ATTR(qsfp5_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 4);
+static SENSOR_DEVICE_ATTR(qsfp6_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 5);
+static SENSOR_DEVICE_ATTR(qsfp7_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 6);
+static SENSOR_DEVICE_ATTR(qsfp8_rstn,  S_IRUGO | S_IWUSR, show_system_rst1, set_system_rst1, 7);
+static SENSOR_DEVICE_ATTR(qsfp9_rstn,  S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 0);
+static SENSOR_DEVICE_ATTR(qsfp10_rstn, S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 1);
+static SENSOR_DEVICE_ATTR(qsfp11_rstn, S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 2);
+static SENSOR_DEVICE_ATTR(qsfp12_rstn, S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 3);
+static SENSOR_DEVICE_ATTR(qsfp13_rstn, S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 4);
+static SENSOR_DEVICE_ATTR(qsfp14_rstn, S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 5);
+static SENSOR_DEVICE_ATTR(qsfp15_rstn, S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 6);
+static SENSOR_DEVICE_ATTR(qsfp16_rstn, S_IRUGO | S_IWUSR, show_system_rst2, set_system_rst2, 7);
+static SENSOR_DEVICE_ATTR(qsfp17_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 0);
+static SENSOR_DEVICE_ATTR(qsfp18_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 1);
+static SENSOR_DEVICE_ATTR(qsfp19_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 2);
+static SENSOR_DEVICE_ATTR(qsfp20_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 3);
+static SENSOR_DEVICE_ATTR(qsfp21_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 4);
+static SENSOR_DEVICE_ATTR(qsfp22_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 5);
+static SENSOR_DEVICE_ATTR(qsfp23_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 6);
+static SENSOR_DEVICE_ATTR(qsfp24_rstn, S_IRUGO | S_IWUSR, show_system_rst3, set_system_rst3, 7);
+static SENSOR_DEVICE_ATTR(qsfp25_rstn, S_IRUGO | S_IWUSR, show_system_rst4, set_system_rst4, 0);
+static SENSOR_DEVICE_ATTR(qsfp26_rstn, S_IRUGO | S_IWUSR, show_system_rst4, set_system_rst4, 1);
+static SENSOR_DEVICE_ATTR(qsfp27_rstn, S_IRUGO | S_IWUSR, show_system_rst4, set_system_rst4, 2);
+static SENSOR_DEVICE_ATTR(qsfp28_rstn, S_IRUGO | S_IWUSR, show_system_rst4, set_system_rst4, 3);
+static SENSOR_DEVICE_ATTR(qsfp29_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 0);
+static SENSOR_DEVICE_ATTR(qsfp30_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 1);
+static SENSOR_DEVICE_ATTR(qsfp31_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 2);
+static SENSOR_DEVICE_ATTR(qsfp32_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 3);
+static SENSOR_DEVICE_ATTR(qsfp33_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 4);
+static SENSOR_DEVICE_ATTR(qsfp34_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 5);
+static SENSOR_DEVICE_ATTR(qsfp35_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 6);
+static SENSOR_DEVICE_ATTR(qsfp36_rstn, S_IRUGO | S_IWUSR, show_system_rst5, set_system_rst5, 7);
+static SENSOR_DEVICE_ATTR(i2c_sw1_rstn, S_IRUGO | S_IWUSR, show_system_rst6, set_system_rst6, I2C_SW1_RST);
+static SENSOR_DEVICE_ATTR(i2c_sw2_rstn, S_IRUGO | S_IWUSR, show_system_rst6, set_system_rst6, I2C_SW2_RST);
+static SENSOR_DEVICE_ATTR(i2c_sw3_rstn, S_IRUGO | S_IWUSR, show_system_rst6, set_system_rst6, I2C_SW3_RST);
+static SENSOR_DEVICE_ATTR(i2c_sw4_rstn, S_IRUGO | S_IWUSR, show_system_rst6, set_system_rst6, I2C_SW4_RST);
+static SENSOR_DEVICE_ATTR(i2c_sw5_rstn, S_IRUGO | S_IWUSR, show_system_rst6, set_system_rst6, I2C_SW5_RST);
+static SENSOR_DEVICE_ATTR(i2c_sw6_rstn, S_IRUGO | S_IWUSR, show_system_rst6, set_system_rst6, I2C_SW6_RST);
+static SENSOR_DEVICE_ATTR(i2c_sw7_rstn, S_IRUGO | S_IWUSR, show_system_rst6, set_system_rst6, I2C_SW7_RST);
+static SENSOR_DEVICE_ATTR(qsfp1_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 0);
+static SENSOR_DEVICE_ATTR(qsfp2_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 1);
+static SENSOR_DEVICE_ATTR(qsfp3_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 2);
+static SENSOR_DEVICE_ATTR(qsfp4_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 3);
+static SENSOR_DEVICE_ATTR(qsfp5_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 4);
+static SENSOR_DEVICE_ATTR(qsfp6_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 5);
+static SENSOR_DEVICE_ATTR(qsfp7_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 6);
+static SENSOR_DEVICE_ATTR(qsfp8_mod_prsnt, S_IRUGO, show_module_prsnt2, NULL, 7);
+static SENSOR_DEVICE_ATTR(qsfp9_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 0);
+static SENSOR_DEVICE_ATTR(qsfp10_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 1);
+static SENSOR_DEVICE_ATTR(qsfp11_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 2);
+static SENSOR_DEVICE_ATTR(qsfp12_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 3);
+static SENSOR_DEVICE_ATTR(qsfp13_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 4);
+static SENSOR_DEVICE_ATTR(qsfp14_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 5);
+static SENSOR_DEVICE_ATTR(qsfp15_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 6);
+static SENSOR_DEVICE_ATTR(qsfp16_mod_prsnt, S_IRUGO, show_module_prsnt3, NULL, 7);
+static SENSOR_DEVICE_ATTR(qsfp17_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 0);
+static SENSOR_DEVICE_ATTR(qsfp18_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 1);
+static SENSOR_DEVICE_ATTR(qsfp19_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 2);
+static SENSOR_DEVICE_ATTR(qsfp20_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 3);
+static SENSOR_DEVICE_ATTR(qsfp21_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 4);
+static SENSOR_DEVICE_ATTR(qsfp22_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 5);
+static SENSOR_DEVICE_ATTR(qsfp23_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 6);
+static SENSOR_DEVICE_ATTR(qsfp24_mod_prsnt, S_IRUGO, show_module_prsnt4, NULL, 7);
+static SENSOR_DEVICE_ATTR(qsfp25_mod_prsnt, S_IRUGO, show_module_prsnt5, NULL, 0);
+static SENSOR_DEVICE_ATTR(qsfp26_mod_prsnt, S_IRUGO, show_module_prsnt5, NULL, 1);
+static SENSOR_DEVICE_ATTR(qsfp27_mod_prsnt, S_IRUGO, show_module_prsnt5, NULL, 2);
+static SENSOR_DEVICE_ATTR(qsfp28_mod_prsnt, S_IRUGO, show_module_prsnt5, NULL, 3);
+static SENSOR_DEVICE_ATTR(qsfp29_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 0);
+static SENSOR_DEVICE_ATTR(qsfp30_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 1);
+static SENSOR_DEVICE_ATTR(qsfp31_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 2);
+static SENSOR_DEVICE_ATTR(qsfp32_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 3);
+static SENSOR_DEVICE_ATTR(qsfp33_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 4);
+static SENSOR_DEVICE_ATTR(qsfp34_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 5);
+static SENSOR_DEVICE_ATTR(qsfp35_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 6);
+static SENSOR_DEVICE_ATTR(qsfp36_mod_prsnt, S_IRUGO, show_module_prsnt1, NULL, 7);
+static SENSOR_DEVICE_ATTR(psu1_led, S_IRUGO | S_IWUSR, show_system_led1, set_system_led1, PSU1_LED_MASK);
+static SENSOR_DEVICE_ATTR(psu2_led, S_IRUGO | S_IWUSR, show_system_led1, set_system_led1, PSU2_LED_MASK);
+static SENSOR_DEVICE_ATTR(fan_led, S_IRUGO | S_IWUSR, show_system_led1, set_system_led1, FAN_LED_MASK);
+static SENSOR_DEVICE_ATTR(sys_led, S_IRUGO | S_IWUSR, show_system_led2, set_system_led2, SYSTEM_LED_MASK);
+static SENSOR_DEVICE_ATTR(qsfp1_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 0);
+static SENSOR_DEVICE_ATTR(qsfp2_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 1);
+static SENSOR_DEVICE_ATTR(qsfp3_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 2);
+static SENSOR_DEVICE_ATTR(qsfp4_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 3);
+static SENSOR_DEVICE_ATTR(qsfp5_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 4);
+static SENSOR_DEVICE_ATTR(qsfp6_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 5);
+static SENSOR_DEVICE_ATTR(qsfp7_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 6);
+static SENSOR_DEVICE_ATTR(qsfp8_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 7);
+static SENSOR_DEVICE_ATTR(qsfp9_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 8);
+static SENSOR_DEVICE_ATTR(qsfp10_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 9);
+static SENSOR_DEVICE_ATTR(qsfp11_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 10);
+static SENSOR_DEVICE_ATTR(qsfp12_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 11);
+static SENSOR_DEVICE_ATTR(qsfp13_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 12);
+static SENSOR_DEVICE_ATTR(qsfp14_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 13);
+static SENSOR_DEVICE_ATTR(qsfp15_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 14);
+static SENSOR_DEVICE_ATTR(qsfp16_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 15);
+static SENSOR_DEVICE_ATTR(qsfp17_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 16);
+static SENSOR_DEVICE_ATTR(qsfp18_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 17);
+static SENSOR_DEVICE_ATTR(qsfp19_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 18);
+static SENSOR_DEVICE_ATTR(qsfp20_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 19);
+static SENSOR_DEVICE_ATTR(qsfp21_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 20);
+static SENSOR_DEVICE_ATTR(qsfp22_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 21);
+static SENSOR_DEVICE_ATTR(qsfp23_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 22);
+static SENSOR_DEVICE_ATTR(qsfp24_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 23);
+static SENSOR_DEVICE_ATTR(qsfp25_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 24);
+static SENSOR_DEVICE_ATTR(qsfp26_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 25);
+static SENSOR_DEVICE_ATTR(qsfp27_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 26);
+static SENSOR_DEVICE_ATTR(qsfp28_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 27);
+static SENSOR_DEVICE_ATTR(qsfp29_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 28);
+static SENSOR_DEVICE_ATTR(qsfp30_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 29);
+static SENSOR_DEVICE_ATTR(qsfp31_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 30);
+static SENSOR_DEVICE_ATTR(qsfp32_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 31);
+static SENSOR_DEVICE_ATTR(qsfp33_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 32);
+static SENSOR_DEVICE_ATTR(qsfp34_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 33);
+static SENSOR_DEVICE_ATTR(qsfp35_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 34);
+static SENSOR_DEVICE_ATTR(qsfp36_reset, S_IRUGO | S_IWUSR, show_qsfp_reset, set_qsfp_reset, 35);
+static SENSOR_DEVICE_ATTR(bulk_qsfp_reset, S_IRUGO | S_IWUSR, show_bulk_qsfp_reset, set_bulk_qsfp_reset, 0);
+
+static struct attribute *d4_cpld1_attributes[] = {
+    &sensor_dev_attr_pcb_ver.dev_attr.attr,
+    &sensor_dev_attr_cpld_ver.dev_attr.attr,
+    &sensor_dev_attr_psu1_present.dev_attr.attr,
+    &sensor_dev_attr_psu2_present.dev_attr.attr,
+    &sensor_dev_attr_psu1_pwr_ok.dev_attr.attr,
+    &sensor_dev_attr_psu2_pwr_ok.dev_attr.attr,
+    &sensor_dev_attr_psu1_input_ok.dev_attr.attr,
+    &sensor_dev_attr_psu2_input_ok.dev_attr.attr,
+    &sensor_dev_attr_psu1_power_ok.dev_attr.attr,
+    &sensor_dev_attr_psu2_power_ok.dev_attr.attr,
+    &sensor_dev_attr_qsfp1_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp17_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp33_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_rstn.dev_attr.attr,
+    &sensor_dev_attr_i2c_sw1_rstn.dev_attr.attr,
+    &sensor_dev_attr_i2c_sw2_rstn.dev_attr.attr,
+    &sensor_dev_attr_i2c_sw3_rstn.dev_attr.attr,
+    &sensor_dev_attr_i2c_sw4_rstn.dev_attr.attr,
+    &sensor_dev_attr_i2c_sw5_rstn.dev_attr.attr,
+    &sensor_dev_attr_i2c_sw6_rstn.dev_attr.attr,
+    &sensor_dev_attr_i2c_sw7_rstn.dev_attr.attr,
+    &sensor_dev_attr_qsfp1_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp17_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp33_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_mod_prsnt.dev_attr.attr,
+    &sensor_dev_attr_psu1_led.dev_attr.attr,
+    &sensor_dev_attr_psu2_led.dev_attr.attr,
+    &sensor_dev_attr_fan_led.dev_attr.attr,
+    &sensor_dev_attr_sys_led.dev_attr.attr,
+    &sensor_dev_attr_qsfp1_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp17_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp33_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_reset.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_reset.dev_attr.attr,
+    &sensor_dev_attr_bulk_qsfp_reset.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group d4_cpld1_group = {
+    .attrs = d4_cpld1_attributes,
+};
+
+static int d4_cpld1_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+    struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia-7220-IXR-D4 CPLD1 chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD1 PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &d4_cpld1_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void d4_cpld1_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &d4_cpld1_group);
+    kfree(data);
+}
+
+static const struct of_device_id d4_cpld1_of_ids[] = {
+    {
+        .compatible = "nokia,d4_cpld1",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, d4_cpld1_of_ids);
+
+static const struct i2c_device_id d4_cpld1_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, d4_cpld1_ids);
+
+static struct i2c_driver d4_cpld1_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(d4_cpld1_of_ids),
+    },
+    .probe        = d4_cpld1_probe,
+    .remove       = d4_cpld1_remove,
+    .id_table     = d4_cpld1_ids,
+    .address_list = cpld1_address_list,
+};
+
+static int __init d4_cpld1_init(void)
+{
+    return i2c_add_driver(&d4_cpld1_driver);
+}
+
+static void __exit d4_cpld1_exit(void)
+{
+    i2c_del_driver(&d4_cpld1_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA-7220-IXR-D4 CPLD1 driver");
+MODULE_LICENSE("GPL");
+
+module_init(d4_cpld1_init);
+module_exit(d4_cpld1_exit);

--- a/ixr7220d4/modules/d4_cpld2.c
+++ b/ixr7220d4/modules/d4_cpld2.c
@@ -1,0 +1,614 @@
+
+//  * CPLD driver for Nokia-7220-IXR-H4-32D
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  *
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "d4_cpld2"
+
+#define CPLD2_VER_REG                     0x01
+#define CPLD2_INTERRUPT_REG               0x02
+
+#define QSPFPDD_P08_01_LOOP_REG           0x40
+#define QSPFP28_P28_21_LOOP_REG           0x41
+#define QSPFP28_P20_19_LOOP_REG           0x42
+#define QSPFPDD_P08_01_PRES_REG           0x43
+#define QSPFP28_P28_21_PRES_REG           0x44
+#define QSPFP28_P20_19_PRES_REG           0x45
+#define QSPFPDD_P08_01_PORT_STATUS_REG    0x46
+#define QSPFP28_P28_21_PORT_STATUS_REG    0x47
+#define QSPFP28_P20_19_PORT_STATUS_REG    0x48
+
+#define QSPFP28_P20      0x1
+#define QSPFP28_P19      0x0
+
+#define QSPFP28_P28      0x7
+#define QSPFP28_P27      0x6
+#define QSPFP28_P26      0x5
+#define QSPFP28_P25      0x4
+#define QSPFP28_P24      0x3
+#define QSPFP28_P23      0x2
+#define QSPFP28_P22      0x1
+#define QSPFP28_P21      0x0
+
+#define QSFPDD_P8       0x7
+#define QSFPDD_P7       0x6
+#define QSFPDD_P6       0x5
+#define QSFPDD_P5       0x4
+#define QSFPDD_P4       0x3
+#define QSFPDD_P3       0x2
+#define QSFPDD_P2       0x1
+#define QSFPDD_P1       0x0
+
+
+static const unsigned short cpld2_address_list[] = {0x62, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex update_lock;
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD2 READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD2 WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+static ssize_t show_cpld_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, CPLD2_VER_REG);
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+static ssize_t show_module_lo0(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+     struct cpld_data *data = dev_get_drvdata(dev);
+     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+     u8 val = 0;
+     val = cpld_i2c_read(data,QSPFPDD_P08_01_LOOP_REG );
+
+     return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_lo0(struct device *dev, struct device_attribute *devattr,  const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFPDD_P08_01_LOOP_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFPDD_P08_01_LOOP_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_module_lo1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+     struct cpld_data *data = dev_get_drvdata(dev);
+     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+     u8 val = 0;
+     val = cpld_i2c_read(data,QSPFP28_P28_21_LOOP_REG );
+
+     return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_lo1(struct device *dev, struct device_attribute *devattr,  const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFP28_P28_21_LOOP_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFP28_P28_21_LOOP_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_module_lo2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+     struct cpld_data *data = dev_get_drvdata(dev);
+     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+     u8 val = 0;
+     val = cpld_i2c_read(data, QSPFP28_P20_19_LOOP_REG);
+
+     return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_lo2(struct device *dev, struct device_attribute *devattr,  const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFP28_P20_19_LOOP_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFP28_P20_19_LOOP_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_module_present0(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSPFPDD_P08_01_PRES_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_present0(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFPDD_P08_01_PRES_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFPDD_P08_01_PRES_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_module_present1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSPFP28_P28_21_PRES_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_present1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFP28_P28_21_PRES_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFP28_P28_21_PRES_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_module_present2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSPFP28_P20_19_PRES_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_present2(struct device *dev, struct device_attribute *devattr,const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFP28_P20_19_PRES_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFP28_P20_19_PRES_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_port_status0(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSPFPDD_P08_01_PORT_STATUS_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_port_status0(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFPDD_P08_01_PORT_STATUS_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFPDD_P08_01_PORT_STATUS_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+static ssize_t show_port_status1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSPFP28_P28_21_PORT_STATUS_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_port_status1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFP28_P28_21_PORT_STATUS_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFP28_P28_21_PORT_STATUS_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+
+static ssize_t show_port_status2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSPFP28_P20_19_PORT_STATUS_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_port_status2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSPFP28_P20_19_PORT_STATUS_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSPFP28_P20_19_PORT_STATUS_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+
+static SENSOR_DEVICE_ATTR(cpld_ver, S_IRUGO, show_cpld_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(qsfp36_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P8);
+static SENSOR_DEVICE_ATTR(qsfp35_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P7);
+static SENSOR_DEVICE_ATTR(qsfp34_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P6);
+static SENSOR_DEVICE_ATTR(qsfp33_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P5);
+static SENSOR_DEVICE_ATTR(qsfp32_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P4);
+static SENSOR_DEVICE_ATTR(qsfp31_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P3);
+static SENSOR_DEVICE_ATTR(qsfp30_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P2);
+static SENSOR_DEVICE_ATTR(qsfp29_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFPDD_P1);
+static SENSOR_DEVICE_ATTR(qsfp28_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P28);
+static SENSOR_DEVICE_ATTR(qsfp27_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P27);
+static SENSOR_DEVICE_ATTR(qsfp26_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P26);
+static SENSOR_DEVICE_ATTR(qsfp25_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P25);
+static SENSOR_DEVICE_ATTR(qsfp24_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P24);
+static SENSOR_DEVICE_ATTR(qsfp23_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P23);
+static SENSOR_DEVICE_ATTR(qsfp22_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P22);
+static SENSOR_DEVICE_ATTR(qsfp21_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSPFP28_P21);
+static SENSOR_DEVICE_ATTR(qsfp20_lo, S_IRUGO | S_IWUSR, show_module_lo2, set_module_lo2, QSPFP28_P20);
+static SENSOR_DEVICE_ATTR(qsfp19_lo, S_IRUGO | S_IWUSR, show_module_lo2, set_module_lo2, QSPFP28_P19);
+static SENSOR_DEVICE_ATTR(qsfp36_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P8);
+static SENSOR_DEVICE_ATTR(qsfp35_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P7);
+static SENSOR_DEVICE_ATTR(qsfp34_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P6);
+static SENSOR_DEVICE_ATTR(qsfp33_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P5);
+static SENSOR_DEVICE_ATTR(qsfp32_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P4);
+static SENSOR_DEVICE_ATTR(qsfp31_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P3);
+static SENSOR_DEVICE_ATTR(qsfp30_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P2);
+static SENSOR_DEVICE_ATTR(qsfp29_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFPDD_P1);
+static SENSOR_DEVICE_ATTR(qsfp28_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P28);
+static SENSOR_DEVICE_ATTR(qsfp27_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P27);
+static SENSOR_DEVICE_ATTR(qsfp26_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P26);
+static SENSOR_DEVICE_ATTR(qsfp25_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P25);
+static SENSOR_DEVICE_ATTR(qsfp24_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P24);
+static SENSOR_DEVICE_ATTR(qsfp23_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P23);
+static SENSOR_DEVICE_ATTR(qsfp22_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P22);
+static SENSOR_DEVICE_ATTR(qsfp21_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSPFP28_P21);
+static SENSOR_DEVICE_ATTR(qsfp20_prs, S_IRUGO | S_IWUSR, show_module_present2, set_module_present2, QSPFP28_P20);
+static SENSOR_DEVICE_ATTR(qsfp19_prs, S_IRUGO | S_IWUSR, show_module_present2, set_module_present2, QSPFP28_P19);
+static SENSOR_DEVICE_ATTR(qsfp36_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P8);
+static SENSOR_DEVICE_ATTR(qsfp35_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P7);
+static SENSOR_DEVICE_ATTR(qsfp34_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P6);
+static SENSOR_DEVICE_ATTR(qsfp33_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P5);
+static SENSOR_DEVICE_ATTR(qsfp32_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P4);
+static SENSOR_DEVICE_ATTR(qsfp31_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P3);
+static SENSOR_DEVICE_ATTR(qsfp30_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P2);
+static SENSOR_DEVICE_ATTR(qsfp29_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFPDD_P1);
+static SENSOR_DEVICE_ATTR(qsfp28_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P28);
+static SENSOR_DEVICE_ATTR(qsfp27_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P27);
+static SENSOR_DEVICE_ATTR(qsfp26_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P26);
+static SENSOR_DEVICE_ATTR(qsfp25_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P25);
+static SENSOR_DEVICE_ATTR(qsfp24_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P24);
+static SENSOR_DEVICE_ATTR(qsfp23_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P23);
+static SENSOR_DEVICE_ATTR(qsfp22_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P22);
+static SENSOR_DEVICE_ATTR(qsfp21_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSPFP28_P21);
+static SENSOR_DEVICE_ATTR(qsfp20_port, S_IRUGO | S_IWUSR, show_port_status2, set_port_status2, QSPFP28_P20);
+static SENSOR_DEVICE_ATTR(qsfp19_port, S_IRUGO | S_IWUSR, show_port_status2, set_port_status2, QSPFP28_P19);
+
+
+static struct attribute *d4_cpld2_attributes[] = {
+    &sensor_dev_attr_cpld_ver.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp33_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp33_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp33_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_port.dev_attr.attr,
+    NULL
+
+};
+
+static const struct attribute_group d4_cpld2_group = {
+    .attrs = d4_cpld2_attributes,
+};
+
+static int d4_cpld2_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+    struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD2 PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia-7220-IXR-D4 CPLD2 chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD2 PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &d4_cpld2_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD2 INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void d4_cpld2_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &d4_cpld2_group);
+    kfree(data);
+}
+
+static const struct of_device_id d4_cpld2_of_ids[] = {
+    {
+        .compatible = "nokia,d4_cpld2",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, d4_cpld2_of_ids);
+
+static const struct i2c_device_id d4_cpld2_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, d4_cpld2_ids);
+
+
+static struct i2c_driver d4_cpld2_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(d4_cpld2_of_ids),
+    },
+    .probe        = d4_cpld2_probe,
+    .remove       = d4_cpld2_remove,
+    .id_table     = d4_cpld2_ids,
+    .address_list = cpld2_address_list,
+};
+
+static int __init d4_cpld2_init(void)
+{
+    return i2c_add_driver(&d4_cpld2_driver);
+}
+
+static void __exit d4_cpld2_exit(void)
+{
+    i2c_del_driver(&d4_cpld2_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA-7220-IXR-D4 CPLD2 driver");
+MODULE_LICENSE("GPL");
+
+module_init(d4_cpld2_init);
+module_exit(d4_cpld2_exit);

--- a/ixr7220d4/modules/d4_cpld3.c
+++ b/ixr7220d4/modules/d4_cpld3.c
@@ -1,0 +1,989 @@
+//  * CPLD driver for Nokia-7220-IXR-D4
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  *
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "d4_cpld3"
+
+// REGISTERS ADDRESS MAP
+#define CPLD3_VER_REG                   0x00
+
+#define QSFP28_P18_11_LOOP_REG          0x40
+#define QSFP28_P10_03_LOOP_REG          0x41
+#define QSFP28_P02_01_LOOP_REG          0x42
+#define QSFP28_P18_11_PRES_REG          0x43
+#define QSFP28_P10_03_PRES_REG          0x44
+#define QSFP28_P02_01_PRES_REG          0x45
+#define QSFP28_P18_11_PORT_STATUS_REG   0x46
+#define QSFP28_P10_03_PORT_STATUS_REG   0x47
+#define QSFP28_P02_01_PORT_STATUS_REG   0x48
+#define QSFP28_P08_01_LP_MODE_REG       0x60
+#define QSFP28_P16_09_LP_MODE_REG       0x61
+#define QSFP28_P24_17_LP_MODE_REG       0x62
+#define QSFP28_P28_25_LP_MODE_REG       0x63
+#define QSFPDD_P08_01_LP_MODE_REG       0x64
+
+// REG BIT FIELD POSITION or MASK
+
+#define QSFP28_P18       0x7
+#define QSFP28_P17       0x6
+#define QSFP28_P16       0x5
+#define QSFP28_P15       0x4
+#define QSFP28_P14       0x3
+#define QSFP28_P13       0x2
+#define QSFP28_P12       0x1
+#define QSFP28_P11       0x0
+#define QSFP28_P10       0x7
+#define QSFP28_P09       0x6
+#define QSFP28_P08       0x5
+#define QSFP28_P07       0x4
+#define QSFP28_P06       0x3
+#define QSFP28_P05       0x2
+#define QSFP28_P04       0x1
+#define QSFP28_P03       0x0
+#define QSFP28_P02       0x1
+#define QSFP28_P01       0x0
+
+
+static const unsigned short cpld3_address_list[] = {0x64, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+/* ---------------- */
+
+static void dump_reg(struct cpld_data *data)
+{
+    struct i2c_client *client = data->client;
+    u8 val0 = 0;
+    u8 val1 = 0;
+    u8 val2 = 0;
+    u8 val3 = 0;
+    u8 val4 = 0;
+
+    val0 = cpld_i2c_read(data, QSFP28_P08_01_LP_MODE_REG);
+    val1 = cpld_i2c_read(data, QSFP28_P16_09_LP_MODE_REG);
+    val2 = cpld_i2c_read(data, QSFP28_P24_17_LP_MODE_REG);
+    val3 = cpld_i2c_read(data, QSFP28_P28_25_LP_MODE_REG);
+    val4 = cpld_i2c_read(data, QSFPDD_P08_01_LP_MODE_REG);
+    dev_info(&client->dev, "[CPLD3]QSFP_LPMODE_REG: 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x\n", val0, val1, val2, val3, val4);
+
+}
+
+/* ---------------- */
+
+static ssize_t show_cpld_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, CPLD3_VER_REG);
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+/* ---------------- */
+
+static ssize_t show_module_lo0(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P18_11_LOOP_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_lo0(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P18_11_LOOP_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P18_11_LOOP_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_module_lo1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P10_03_LOOP_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_lo1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P10_03_LOOP_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P10_03_LOOP_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_module_lo2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P02_01_LOOP_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_lo2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P02_01_LOOP_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P02_01_LOOP_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_module_present0(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P18_11_PRES_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_present0(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P18_11_PRES_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P18_11_PRES_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_module_present1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P10_03_PRES_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_present1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P10_03_PRES_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P10_03_PRES_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_module_present2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P02_01_PRES_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_module_present2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P02_01_PRES_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P02_01_PRES_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_port_status0(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P18_11_PORT_STATUS_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_port_status0(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P18_11_PORT_STATUS_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P18_11_PORT_STATUS_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_port_status1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P10_03_PORT_STATUS_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_port_status1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P10_03_PORT_STATUS_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P10_03_PORT_STATUS_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_port_status2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P02_01_PORT_STATUS_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_port_status2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P02_01_PORT_STATUS_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P02_01_PORT_STATUS_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_lp_mode0(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P08_01_LP_MODE_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_lp_mode0(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P08_01_LP_MODE_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P08_01_LP_MODE_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_lp_mode1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P16_09_LP_MODE_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_lp_mode1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P16_09_LP_MODE_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P16_09_LP_MODE_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_lp_mode2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P24_17_LP_MODE_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_lp_mode2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P24_17_LP_MODE_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P24_17_LP_MODE_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_lp_mode3(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFP28_P28_25_LP_MODE_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_lp_mode3(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFP28_P28_25_LP_MODE_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFP28_P28_25_LP_MODE_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_lp_mode4(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, QSFPDD_P08_01_LP_MODE_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_lp_mode4(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(0x1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, QSFPDD_P08_01_LP_MODE_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, QSFPDD_P08_01_LP_MODE_REG, (reg_val|usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t set_bulk_qsfp28_lpmod(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 reg_val=0, usr_val=0;
+
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    reg_val = cpld_i2c_read(data, QSFP28_P28_25_LP_MODE_REG);
+    switch(usr_val){
+        case 0:
+            cpld_i2c_write(data, QSFP28_P08_01_LP_MODE_REG, 0x00);
+            cpld_i2c_write(data, QSFP28_P16_09_LP_MODE_REG, 0x00);
+            cpld_i2c_write(data, QSFP28_P24_17_LP_MODE_REG, 0x00);
+            cpld_i2c_write(data, QSFP28_P28_25_LP_MODE_REG, reg_val & 0xF0);
+            break;
+        case 1:
+            cpld_i2c_write(data, QSFP28_P08_01_LP_MODE_REG, 0xFF);
+            cpld_i2c_write(data, QSFP28_P16_09_LP_MODE_REG, 0xFF);
+            cpld_i2c_write(data, QSFP28_P24_17_LP_MODE_REG, 0xFF);
+            cpld_i2c_write(data, QSFP28_P28_25_LP_MODE_REG, reg_val | 0x0F);
+    }
+    dump_reg(data);
+    return count;
+}
+
+static ssize_t show_bulk_qsfp28_lpmod(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+
+    u8 val0 = 0;
+    u8 val1 = 0;
+    u8 val2 = 0;
+    u8 val3 = 0;
+
+    val0 = cpld_i2c_read(data, QSFP28_P08_01_LP_MODE_REG);
+    val1 = cpld_i2c_read(data, QSFP28_P16_09_LP_MODE_REG);
+    val2 = cpld_i2c_read(data, QSFP28_P24_17_LP_MODE_REG);
+    val3 = cpld_i2c_read(data, QSFP28_P28_25_LP_MODE_REG);
+
+    return sprintf(buf, "%d %d %d %d\n", val0, val1, val2, val3);
+}
+
+static ssize_t set_bulk_qsfpdd_lpmod(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 reg_val=0, usr_val=0;
+
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    switch(usr_val){
+        case 0:
+            cpld_i2c_write(data, QSFPDD_P08_01_LP_MODE_REG, 0x00);
+            break;
+        case 1:
+            cpld_i2c_write(data, QSFPDD_P08_01_LP_MODE_REG, 0xFF);
+    }
+    dump_reg(data);
+    return count;
+}
+
+static ssize_t show_bulk_qsfpdd_lpmod(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+
+    u8 val0 = 0;
+    val0 = cpld_i2c_read(data, QSFPDD_P08_01_LP_MODE_REG);
+
+    return sprintf(buf, "%d\n", val0);
+}
+
+// sysfs attributes
+static SENSOR_DEVICE_ATTR(cpld_ver, S_IRUGO, show_cpld_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(qsfp18_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P18);
+static SENSOR_DEVICE_ATTR(qsfp17_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P17);
+static SENSOR_DEVICE_ATTR(qsfp16_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P16);
+static SENSOR_DEVICE_ATTR(qsfp15_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P15);
+static SENSOR_DEVICE_ATTR(qsfp14_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P14);
+static SENSOR_DEVICE_ATTR(qsfp13_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P13);
+static SENSOR_DEVICE_ATTR(qsfp12_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P12);
+static SENSOR_DEVICE_ATTR(qsfp11_lo, S_IRUGO | S_IWUSR, show_module_lo0, set_module_lo0, QSFP28_P11);
+static SENSOR_DEVICE_ATTR(qsfp10_lo, S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P10);
+static SENSOR_DEVICE_ATTR(qsfp9_lo,  S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P09);
+static SENSOR_DEVICE_ATTR(qsfp8_lo,  S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P08);
+static SENSOR_DEVICE_ATTR(qsfp7_lo,  S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P07);
+static SENSOR_DEVICE_ATTR(qsfp6_lo,  S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P06);
+static SENSOR_DEVICE_ATTR(qsfp5_lo,  S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P05);
+static SENSOR_DEVICE_ATTR(qsfp4_lo,  S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P04);
+static SENSOR_DEVICE_ATTR(qsfp3_lo,  S_IRUGO | S_IWUSR, show_module_lo1, set_module_lo1, QSFP28_P03);
+static SENSOR_DEVICE_ATTR(qsfp2_lo,  S_IRUGO | S_IWUSR, show_module_lo2, set_module_lo2, QSFP28_P02);
+static SENSOR_DEVICE_ATTR(qsfp1_lo,  S_IRUGO | S_IWUSR, show_module_lo2, set_module_lo2, QSFP28_P01);
+static SENSOR_DEVICE_ATTR(qsfp18_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P18);
+static SENSOR_DEVICE_ATTR(qsfp17_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P17);
+static SENSOR_DEVICE_ATTR(qsfp16_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P16);
+static SENSOR_DEVICE_ATTR(qsfp15_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P15);
+static SENSOR_DEVICE_ATTR(qsfp14_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P14);
+static SENSOR_DEVICE_ATTR(qsfp13_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P13);
+static SENSOR_DEVICE_ATTR(qsfp12_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P12);
+static SENSOR_DEVICE_ATTR(qsfp11_prs, S_IRUGO | S_IWUSR, show_module_present0, set_module_present0, QSFP28_P11);
+static SENSOR_DEVICE_ATTR(qsfp10_prs, S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P10);
+static SENSOR_DEVICE_ATTR(qsfp9_prs,  S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P09);
+static SENSOR_DEVICE_ATTR(qsfp8_prs,  S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P08);
+static SENSOR_DEVICE_ATTR(qsfp7_prs,  S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P07);
+static SENSOR_DEVICE_ATTR(qsfp6_prs,  S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P06);
+static SENSOR_DEVICE_ATTR(qsfp5_prs,  S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P05);
+static SENSOR_DEVICE_ATTR(qsfp4_prs,  S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P04);
+static SENSOR_DEVICE_ATTR(qsfp3_prs,  S_IRUGO | S_IWUSR, show_module_present1, set_module_present1, QSFP28_P03);
+static SENSOR_DEVICE_ATTR(qsfp2_prs,  S_IRUGO | S_IWUSR, show_module_present2, set_module_present2, QSFP28_P02);
+static SENSOR_DEVICE_ATTR(qsfp1_prs,  S_IRUGO | S_IWUSR, show_module_present2, set_module_present2, QSFP28_P01);
+static SENSOR_DEVICE_ATTR(qsfp18_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P18);
+static SENSOR_DEVICE_ATTR(qsfp17_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P17);
+static SENSOR_DEVICE_ATTR(qsfp16_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P16);
+static SENSOR_DEVICE_ATTR(qsfp15_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P15);
+static SENSOR_DEVICE_ATTR(qsfp14_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P14);
+static SENSOR_DEVICE_ATTR(qsfp13_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P13);
+static SENSOR_DEVICE_ATTR(qsfp12_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P12);
+static SENSOR_DEVICE_ATTR(qsfp11_port, S_IRUGO | S_IWUSR, show_port_status0, set_port_status0, QSFP28_P11);
+static SENSOR_DEVICE_ATTR(qsfp10_port, S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P10);
+static SENSOR_DEVICE_ATTR(qsfp9_port,  S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P09);
+static SENSOR_DEVICE_ATTR(qsfp8_port,  S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P08);
+static SENSOR_DEVICE_ATTR(qsfp7_port,  S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P07);
+static SENSOR_DEVICE_ATTR(qsfp6_port,  S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P06);
+static SENSOR_DEVICE_ATTR(qsfp5_port,  S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P05);
+static SENSOR_DEVICE_ATTR(qsfp4_port,  S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P04);
+static SENSOR_DEVICE_ATTR(qsfp3_port,  S_IRUGO | S_IWUSR, show_port_status1, set_port_status1, QSFP28_P03);
+static SENSOR_DEVICE_ATTR(qsfp2_port,  S_IRUGO | S_IWUSR, show_port_status2, set_port_status2, QSFP28_P02);
+static SENSOR_DEVICE_ATTR(qsfp1_port,  S_IRUGO | S_IWUSR, show_port_status2, set_port_status2, QSFP28_P01);
+static SENSOR_DEVICE_ATTR(qsfp1_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 0);
+static SENSOR_DEVICE_ATTR(qsfp2_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 1);
+static SENSOR_DEVICE_ATTR(qsfp3_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 2);
+static SENSOR_DEVICE_ATTR(qsfp4_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 3);
+static SENSOR_DEVICE_ATTR(qsfp5_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 4);
+static SENSOR_DEVICE_ATTR(qsfp6_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 5);
+static SENSOR_DEVICE_ATTR(qsfp7_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 6);
+static SENSOR_DEVICE_ATTR(qsfp8_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode0, set_lp_mode0, 7);
+static SENSOR_DEVICE_ATTR(qsfp9_lpmod,  S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 0);
+static SENSOR_DEVICE_ATTR(qsfp10_lpmod, S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 1);
+static SENSOR_DEVICE_ATTR(qsfp11_lpmod, S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 2);
+static SENSOR_DEVICE_ATTR(qsfp12_lpmod, S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 3);
+static SENSOR_DEVICE_ATTR(qsfp13_lpmod, S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 4);
+static SENSOR_DEVICE_ATTR(qsfp14_lpmod, S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 5);
+static SENSOR_DEVICE_ATTR(qsfp15_lpmod, S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 6);
+static SENSOR_DEVICE_ATTR(qsfp16_lpmod, S_IRUGO | S_IWUSR, show_lp_mode1, set_lp_mode1, 7);
+static SENSOR_DEVICE_ATTR(qsfp17_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 0);
+static SENSOR_DEVICE_ATTR(qsfp18_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 1);
+static SENSOR_DEVICE_ATTR(qsfp19_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 2);
+static SENSOR_DEVICE_ATTR(qsfp20_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 3);
+static SENSOR_DEVICE_ATTR(qsfp21_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 4);
+static SENSOR_DEVICE_ATTR(qsfp22_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 5);
+static SENSOR_DEVICE_ATTR(qsfp23_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 6);
+static SENSOR_DEVICE_ATTR(qsfp24_lpmod, S_IRUGO | S_IWUSR, show_lp_mode2, set_lp_mode2, 7);
+static SENSOR_DEVICE_ATTR(qsfp25_lpmod, S_IRUGO | S_IWUSR, show_lp_mode3, set_lp_mode3, 0);
+static SENSOR_DEVICE_ATTR(qsfp26_lpmod, S_IRUGO | S_IWUSR, show_lp_mode3, set_lp_mode3, 1);
+static SENSOR_DEVICE_ATTR(qsfp27_lpmod, S_IRUGO | S_IWUSR, show_lp_mode3, set_lp_mode3, 2);
+static SENSOR_DEVICE_ATTR(qsfp28_lpmod, S_IRUGO | S_IWUSR, show_lp_mode3, set_lp_mode3, 3);
+static SENSOR_DEVICE_ATTR(qsfp29_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 0);
+static SENSOR_DEVICE_ATTR(qsfp30_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 1);
+static SENSOR_DEVICE_ATTR(qsfp31_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 2);
+static SENSOR_DEVICE_ATTR(qsfp32_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 3);
+static SENSOR_DEVICE_ATTR(qsfp33_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 4);
+static SENSOR_DEVICE_ATTR(qsfp34_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 5);
+static SENSOR_DEVICE_ATTR(qsfp35_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 6);
+static SENSOR_DEVICE_ATTR(qsfp36_lpmod, S_IRUGO | S_IWUSR, show_lp_mode4, set_lp_mode4, 7);
+static SENSOR_DEVICE_ATTR(bulk_qsfp28_lpmod, S_IRUGO | S_IWUSR, show_bulk_qsfp28_lpmod, set_bulk_qsfp28_lpmod, 0);
+static SENSOR_DEVICE_ATTR(bulk_qsfpdd_lpmod, S_IRUGO | S_IWUSR, show_bulk_qsfpdd_lpmod, set_bulk_qsfpdd_lpmod, 0);
+
+static struct attribute *d4_cpld3_attributes[] = {
+    &sensor_dev_attr_cpld_ver.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp17_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp1_lo.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp17_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp1_prs.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp17_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp1_port.dev_attr.attr,
+    &sensor_dev_attr_qsfp1_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp2_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp3_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp4_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp5_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp6_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp7_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp8_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp9_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp10_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp11_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp12_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp13_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp14_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp15_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp16_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp17_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp18_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp19_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp20_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp21_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp22_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp23_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp24_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp25_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp26_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp27_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp28_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp29_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp30_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp31_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp32_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp33_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp34_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp35_lpmod.dev_attr.attr,
+    &sensor_dev_attr_qsfp36_lpmod.dev_attr.attr,
+    &sensor_dev_attr_bulk_qsfp28_lpmod.dev_attr.attr,
+    &sensor_dev_attr_bulk_qsfpdd_lpmod.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group d4_cpld3_group = {
+    .attrs = d4_cpld3_attributes,
+};
+
+static int d4_cpld3_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+    struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia-7220-IXR-D4 CPLD3 chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD3 PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &d4_cpld3_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void d4_cpld3_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &d4_cpld3_group);
+    kfree(data);
+}
+
+static const struct of_device_id d4_cpld3_of_ids[] = {
+    {
+        .compatible = "nokia,d4_cpld3",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, d4_cpld3_of_ids);
+
+static const struct i2c_device_id d4_cpld3_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, d4_cpld3_ids);
+
+static struct i2c_driver d4_cpld3_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(d4_cpld3_of_ids),
+    },
+    .probe        = d4_cpld3_probe,
+    .remove       = d4_cpld3_remove,
+    .id_table     = d4_cpld3_ids,
+    .address_list = cpld3_address_list,
+};
+
+static int __init d4_cpld3_init(void)
+{
+    return i2c_add_driver(&d4_cpld3_driver);
+}
+
+static void __exit d4_cpld3_exit(void)
+{
+    i2c_del_driver(&d4_cpld3_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA-7220-IXR-D4 CPLD3 driver");
+MODULE_LICENSE("GPL");
+
+module_init(d4_cpld3_init);
+module_exit(d4_cpld3_exit);

--- a/ixr7220d4/modules/d4_cpupld.c
+++ b/ixr7220d4/modules/d4_cpupld.c
@@ -1,0 +1,488 @@
+//  * CPLD driver for Nokia-7220-IXR-D4
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  *
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+#include <linux/delay.h>
+
+#define DRIVER_NAME "d4_cpupld"
+
+// REGISTERS ADDRESS MAP
+#define BOARD_INFO_REG          0x00
+#define CPLD_VER_REG            0x01
+#define WATCHDOG_REG1           0x02
+#define WATCHDOG_REG2           0x03
+#define SYSTEM_RST_REG          0x04
+#define PWR_RAIL_REG1           0x05
+#define PWR_RAIL_REG2           0x06
+#define CPU_STATUS_REG          0x08
+#define LAST_RST_REG            0x24
+
+
+// REG BIT FIELD POSITION or MASK
+#define BOARD_INFO_REG_PCB_VER_MSK            0xF
+#define BOARD_INFO_REG_PWR_CAT                0x4
+#define WATCHDOG_REG1_LT_SPI_CS_SEL           0x3
+#define WATCHDOG_REG1_SPI_CS_SEL              0x4
+#define WATCHDOG_REG1_RST_LOG_CLR             0x6
+#define WATCHDOG_REG1_OS_DONE                 0x7
+#define WATCHDOG_REG2_TEST_MODE               0x0
+#define WATCHDOG_REG2_WDT                     0x1
+#define WATCHDOG_REG2_BOOT_DEV_SEL            0x2
+#define WATCHDOG_REG2_UPD_BOOT_DEV_SEL        0x3
+#define WATCHDOG_REG2_WATCHDOG_EN             0x4
+#define SOFT_RST                              0x0
+#define CPU_JTAG_RST                          0x1
+#define COLD_RST                              0x3
+#define I210_RST_L_MASK                       0x5
+#define PWR_RAIL_REG1_PWRGD_P3V3              0x0
+#define PWR_RAIL_REG1_PWRGD_P1V5_PCH          0x1
+#define PWR_RAIL_REG1_PWRGD_P1V05_PCH         0x2
+#define PWR_RAIL_REG1_PWRGD_P0V6_VTT_DIMM     0x3
+#define PWR_RAIL_REG1_PWRGD_DDR4_VPP          0x4
+#define PWR_RAIL_REG1_PCH_SLP_S3_N            0x5
+#define PWR_RAIL_REG1_CPU_XDP_SYSPWROK        0x6
+#define PWR_RAIL_REG1_C33_BDX_PWRGOOD_CPU     0x7
+#define PWR_RAIL_REG2_VR_P1V2_VDDQ            0x0
+#define PWR_RAIL_REG2_PVCCSCFUSESUS           0x1
+#define PWR_RAIL_REG2_PVCCKRHV                0x2
+#define PWR_RAIL_REG2_PVCCIN                  0x3
+#define PWR_RAIL_REG2_P5V_STBY                0x4
+#define CPU_STATUS_REG_LSB_MSK                0xF
+#define CPU_STATUS_REG_MSB                    0x4
+
+
+static const unsigned short cpld_address_list[] = {0x65, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int reset_cause;
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+/* ---------------- */
+
+static ssize_t show_pcb_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    char *str_ver = NULL;
+    u8 val = 0;
+    val = cpld_i2c_read(data, BOARD_INFO_REG) & BOARD_INFO_REG_PCB_VER_MSK;
+
+    switch (val) {
+    case 0xA:
+        str_ver = "R0A";
+        break;
+    case 0xB:
+        str_ver = "R0B";
+        break;
+    default: // 0x1
+        str_ver = "R01";
+        break;
+    }
+
+    return sprintf(buf, "0x%x %s\n", val, str_ver);
+}
+
+/* ---------------- */
+
+static ssize_t show_board_power_cat(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, BOARD_INFO_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_cpld_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, CPLD_VER_REG);
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+/* ---------------- */
+
+static ssize_t show_watchdog1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, WATCHDOG_REG1);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_watchdog1(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val = 0;
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, WATCHDOG_REG1);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+    cpld_i2c_write(data, WATCHDOG_REG1, (reg_val | usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_watchdog2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, WATCHDOG_REG2);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_watchdog2(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val = 0;
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, WATCHDOG_REG2);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+    cpld_i2c_write(data, WATCHDOG_REG2, (reg_val | usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_system_rst(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, SYSTEM_RST_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_system_rst(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val = 0;
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, SYSTEM_RST_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+    cpld_i2c_write(data, SYSTEM_RST_REG, (reg_val | usr_val));
+
+    return count;
+}
+
+/* ---------------- */
+
+static ssize_t show_pwr_rail1(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, PWR_RAIL_REG1);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_pwr_rail2(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    val = cpld_i2c_read(data, PWR_RAIL_REG2);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------------- */
+
+static ssize_t show_lsb_post_code(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, CPU_STATUS_REG) & CPU_STATUS_REG_LSB_MSK;
+    return sprintf(buf, "0x%x\n", val);
+}
+
+static ssize_t show_msb_post_code(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, CPU_STATUS_REG) >> CPU_STATUS_REG_MSB;
+    return sprintf(buf, "0x%x\n", val);
+}
+
+/* ---------------- */
+
+static ssize_t show_last_rst(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%02x\n", data->reset_cause);
+}
+
+
+
+// sysfs attributes
+static SENSOR_DEVICE_ATTR(pcb_ver, S_IRUGO, show_pcb_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(board_power_cat, S_IRUGO, show_board_power_cat, NULL, 0);
+static SENSOR_DEVICE_ATTR(cpld_ver, S_IRUGO, show_cpld_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(wd1_lt_spi_cs_sel, S_IRUGO, show_watchdog1, NULL, WATCHDOG_REG1_LT_SPI_CS_SEL);
+static SENSOR_DEVICE_ATTR(wd1_spi_cs_sel, S_IRUGO, show_watchdog1, NULL, WATCHDOG_REG1_SPI_CS_SEL);
+static SENSOR_DEVICE_ATTR(wd1_rst_log_clr, S_IRUGO | S_IWUSR, show_watchdog1, set_watchdog1, WATCHDOG_REG1_RST_LOG_CLR);
+static SENSOR_DEVICE_ATTR(wd1_os_done, S_IRUGO | S_IWUSR, show_watchdog1, set_watchdog1, WATCHDOG_REG1_OS_DONE);
+static SENSOR_DEVICE_ATTR(wd2_test_mode, S_IRUGO | S_IWUSR, show_watchdog2, set_watchdog2, WATCHDOG_REG2_TEST_MODE);
+static SENSOR_DEVICE_ATTR(wd2_wdt, S_IRUGO | S_IWUSR, show_watchdog2, set_watchdog2, WATCHDOG_REG2_WDT);
+static SENSOR_DEVICE_ATTR(wd2_boot_dev_sel, S_IRUGO | S_IWUSR, show_watchdog2, set_watchdog2, WATCHDOG_REG2_BOOT_DEV_SEL);
+static SENSOR_DEVICE_ATTR(wd2_upd_boot_dev_sel, S_IRUGO | S_IWUSR, show_watchdog2, set_watchdog2, WATCHDOG_REG2_UPD_BOOT_DEV_SEL);
+static SENSOR_DEVICE_ATTR(wd2_enable, S_IRUGO | S_IWUSR, show_watchdog2, set_watchdog2, WATCHDOG_REG2_WATCHDOG_EN);
+static SENSOR_DEVICE_ATTR(soft_rst, S_IRUGO | S_IWUSR, show_system_rst, set_system_rst, SOFT_RST);
+static SENSOR_DEVICE_ATTR(cpu_jtag_rst, S_IRUGO | S_IWUSR, show_system_rst, set_system_rst, CPU_JTAG_RST);
+static SENSOR_DEVICE_ATTR(cold_rst, S_IRUGO | S_IWUSR, show_system_rst, set_system_rst, COLD_RST);
+static SENSOR_DEVICE_ATTR(i210_rst_l_mask, S_IRUGO | S_IWUSR, show_system_rst, set_system_rst, I210_RST_L_MASK);
+static SENSOR_DEVICE_ATTR(pwr_rail1_p3v3_pg, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_PWRGD_P3V3);
+static SENSOR_DEVICE_ATTR(pwr_rail1_p1v5_pg, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_PWRGD_P1V5_PCH);
+static SENSOR_DEVICE_ATTR(pwr_rail1_p1v05_pg, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_PWRGD_P1V05_PCH);
+static SENSOR_DEVICE_ATTR(pwr_rail1_p0v6_vtt_pg, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_PWRGD_P0V6_VTT_DIMM);
+static SENSOR_DEVICE_ATTR(pwr_rail1_ddr4_vpp_pg, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_PWRGD_DDR4_VPP);
+static SENSOR_DEVICE_ATTR(pwr_rail1_slp_s3_n, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_PCH_SLP_S3_N);
+static SENSOR_DEVICE_ATTR(pwr_rail1_xdp_syspwok, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_CPU_XDP_SYSPWROK);
+static SENSOR_DEVICE_ATTR(pwr_rail1_procpwrgd_pch, S_IRUGO, show_pwr_rail1, NULL, PWR_RAIL_REG1_C33_BDX_PWRGOOD_CPU);
+static SENSOR_DEVICE_ATTR(pwr_rail2_p1v2, S_IRUGO, show_pwr_rail2, NULL, PWR_RAIL_REG2_VR_P1V2_VDDQ);
+static SENSOR_DEVICE_ATTR(pwr_rail2_pvccscfusesus, S_IRUGO, show_pwr_rail2, NULL, PWR_RAIL_REG2_PVCCSCFUSESUS);
+static SENSOR_DEVICE_ATTR(pwr_rail2_pvcckrhv, S_IRUGO, show_pwr_rail2, NULL, PWR_RAIL_REG2_PVCCKRHV);
+static SENSOR_DEVICE_ATTR(pwr_rail2_p1v8, S_IRUGO, show_pwr_rail2, NULL, PWR_RAIL_REG2_PVCCIN);
+static SENSOR_DEVICE_ATTR(pwr_rail2_p5v, S_IRUGO, show_pwr_rail2, NULL, PWR_RAIL_REG2_P5V_STBY);
+static SENSOR_DEVICE_ATTR(lsb_post_code, S_IRUGO, show_lsb_post_code, NULL, 0);
+static SENSOR_DEVICE_ATTR(msb_post_code, S_IRUGO, show_msb_post_code, NULL, 0);
+static SENSOR_DEVICE_ATTR(reset_cause, S_IRUGO, show_last_rst, NULL, 0);
+
+static struct attribute *d4_cpupld_attributes[] = {
+    &sensor_dev_attr_pcb_ver.dev_attr.attr,
+    &sensor_dev_attr_board_power_cat.dev_attr.attr,
+    &sensor_dev_attr_cpld_ver.dev_attr.attr,
+    &sensor_dev_attr_wd1_lt_spi_cs_sel.dev_attr.attr,
+    &sensor_dev_attr_wd1_spi_cs_sel.dev_attr.attr,
+    &sensor_dev_attr_wd1_rst_log_clr.dev_attr.attr,
+    &sensor_dev_attr_wd1_os_done.dev_attr.attr,
+    &sensor_dev_attr_wd2_test_mode.dev_attr.attr,
+    &sensor_dev_attr_wd2_wdt.dev_attr.attr,
+    &sensor_dev_attr_wd2_boot_dev_sel.dev_attr.attr,
+    &sensor_dev_attr_wd2_upd_boot_dev_sel.dev_attr.attr,
+    &sensor_dev_attr_wd2_enable.dev_attr.attr,
+    &sensor_dev_attr_soft_rst.dev_attr.attr,
+    &sensor_dev_attr_cpu_jtag_rst.dev_attr.attr,
+    &sensor_dev_attr_cold_rst.dev_attr.attr,
+    &sensor_dev_attr_i210_rst_l_mask.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_p3v3_pg.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_p1v5_pg.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_p1v05_pg.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_p0v6_vtt_pg.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_ddr4_vpp_pg.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_slp_s3_n.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_xdp_syspwok.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail1_procpwrgd_pch.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail2_p1v2.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail2_pvccscfusesus.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail2_pvcckrhv.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail2_p1v8.dev_attr.attr,
+    &sensor_dev_attr_pwr_rail2_p5v.dev_attr.attr,
+    &sensor_dev_attr_lsb_post_code.dev_attr.attr,
+    &sensor_dev_attr_msb_post_code.dev_attr.attr,
+    &sensor_dev_attr_reset_cause.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group d4_cpupld_group = {
+    .attrs = d4_cpupld_attributes,
+};
+
+static int d4_cpupld_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+    struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia-7220-IXR-D4 CPU CPLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &d4_cpupld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    data->reset_cause = cpld_i2c_read(data, LAST_RST_REG);
+    u8 val = cpld_i2c_read(data, WATCHDOG_REG1);
+    cpld_i2c_write(data, WATCHDOG_REG1, val | 0x40);
+    dev_info(&client->dev, "[CPU CPLD]: Clear RST reason\n");
+    msleep(200);
+    cpld_i2c_write(data, WATCHDOG_REG1, val & 0xBF);
+    msleep(200);
+    dev_info(&client->dev, "[CPU CPLD]: Clear RST reason .. done\n");
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void d4_cpupld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &d4_cpupld_group);
+    kfree(data);
+}
+
+static const struct of_device_id d4_cpupld_of_ids[] = {
+    {
+        .compatible = "nokia,d4_cpupld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, d4_cpupld_of_ids);
+
+static const struct i2c_device_id d4_cpupld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, d4_cpupld_ids);
+
+static struct i2c_driver d4_cpupld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(d4_cpupld_of_ids),
+    },
+    .probe        = d4_cpupld_probe,
+    .remove       = d4_cpupld_remove,
+    .id_table     = d4_cpupld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init d4_cpupld_init(void)
+{
+    return i2c_add_driver(&d4_cpupld_driver);
+}
+
+static void __exit d4_cpupld_exit(void)
+{
+    i2c_del_driver(&d4_cpupld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA-7220-IXR-D4 CPLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(d4_cpupld_init);
+module_exit(d4_cpupld_exit);

--- a/ixr7220d4/modules/fan_cpld.c
+++ b/ixr7220d4/modules/fan_cpld.c
@@ -1,0 +1,569 @@
+//  * FAN CPLD
+//  *
+//  * Copyright (C) 2024 Nokia Corporation.
+//  *
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+
+#define DRIVER_NAME "fan_cpld"
+
+// REGISTERS ADDRESS MAP
+#define FAN_BOARD_INFO_REG          0x00
+#define FAN_CPLD_VER_REG            0x01
+#define FAN_CPLD_RESET_REG          0x04
+#define FAN_PRESENCE_REG            0x0F
+#define FAN_DIR_REG                 0x10
+#define FAN_PWM_REG                 0x11
+#define FAN1_SPEED_REG              0x12
+#define FAN2_SPEED_REG              0x13
+#define FAN3_SPEED_REG              0x14
+#define FAN4_SPEED_REG              0x15
+#define FAN5_SPEED_REG              0x16
+#define FAN6_SPEED_REG              0x17
+#define LED1_DISPLAY_REG            0x1C
+#define LED2_DISPLAY_REG            0x1D
+#define FAN1_R_SPEED_REG            0x22
+#define FAN2_R_SPEED_REG            0x23
+#define FAN3_R_SPEED_REG            0x24
+#define FAN4_R_SPEED_REG            0x25
+#define FAN5_R_SPEED_REG            0x26
+#define FAN6_R_SPEED_REG            0x27
+#define FAN_POWER_REG               0x30
+
+// REG BIT FIELD POSITION or MASK
+#define BOARD_INFO_REG_TYPE_MSK     0x7
+#define FAN_PWM_MSK                 0xF
+#define FAN_CPLD_RESET_BIT          0x7
+
+#define FAN1_PRES                   0x0
+#define FAN2_PRES                   0x1
+#define FAN3_PRES                   0x2
+#define FAN4_PRES                   0x3
+#define FAN5_PRES                   0x4
+#define FAN6_PRES                   0x5
+
+#define FAN1_ID                     0x0
+#define FAN2_ID                     0x1
+#define FAN3_ID                     0x2
+#define FAN4_ID                     0x3
+#define FAN5_ID                     0x4
+#define FAN6_ID                     0x5
+#define FAN7_ID                     0x6
+#define FAN8_ID                     0x7
+#define FAN9_ID                     0x8
+#define FAN10_ID                    0x9
+#define FAN11_ID                    0xA
+#define FAN12_ID                    0xB
+
+#define FAN1_LED_REG                0x0
+#define FAN2_LED_REG                0x2
+#define FAN3_LED_REG                0x0
+#define FAN4_LED_REG                0x2
+#define FAN5_LED_REG                0x4
+#define FAN6_LED_REG                0x6
+
+static const unsigned short cpld_address_list[] = {0x66, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+};
+
+enum fan_led_mode {
+    FAN_LED_BASE,
+    FAN_LED_GREEN,
+    FAN_LED_RED,
+    FAN_LED_OFF
+};
+
+char *fan_led_mode_str[] = {"base", "green", "red", "off"};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_err(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_err(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+/* ---------- */
+
+static ssize_t show_board_type(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = (cpld_i2c_read(data, FAN_BOARD_INFO_REG) >> 2 ) & BOARD_INFO_REG_TYPE_MSK;
+    char *brd_type = NULL;
+
+    switch (val) {
+    case 0:
+        brd_type = "R0A";
+        break;
+    case 1:
+        brd_type = "R0B";
+        break;
+    case 2:
+        brd_type = "R01";
+        break;
+    default:
+        brd_type = "RESERVED";
+        break;
+    }
+
+    return sprintf(buf, "0x%x %s\n", val, brd_type);
+}
+
+/* ---------- */
+
+static ssize_t show_fan_cpld_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, FAN_CPLD_VER_REG);
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+/* ---------- */
+
+static ssize_t show_fan_cpld_reset(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+
+    u8 val = cpld_i2c_read(data, FAN_CPLD_RESET_REG);
+
+    return sprintf(buf,"%d\n",(val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------- */
+
+static ssize_t show_fan_present(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, FAN_PRESENCE_REG);
+
+    /* If the bit is set, fan is not present. So, we are toggling intentionally */
+    return sprintf(buf,"%d\n",(val>>sda->index) & 0x1 ? 0:1);
+}
+
+/* ---------- */
+
+static ssize_t show_fan_direction(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, FAN_DIR_REG);
+
+    return sprintf(buf,"%d\n",(val>>sda->index) & 0x1 ? 1:0);
+}
+
+/* ---------- */
+
+static ssize_t show_fan_pwm(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+
+    u8 val = cpld_i2c_read(data, FAN_PWM_REG) & FAN_PWM_MSK;
+
+    return sprintf(buf,"%d\n", val);
+}
+
+static ssize_t set_fan_pwm(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+
+    u8 reg_val=0, usr_val=0, mask;
+
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 0xF) {
+        return -EINVAL;
+    }
+
+    mask = (~FAN_PWM_MSK) & 0xFF;
+    reg_val = cpld_i2c_read(data, FAN_PWM_REG);
+    reg_val = reg_val & mask;
+
+    cpld_i2c_write(data, FAN_PWM_REG, (reg_val|usr_val));
+
+    return count;
+
+}
+
+/* ---------- */
+
+static ssize_t show_fan_speed(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    u8 speed_reg = 0;
+    int val_rpm = 0;
+    switch (sda->index) {
+    case 0:
+        speed_reg = FAN1_SPEED_REG;
+        break;
+    case 1:
+        speed_reg = FAN1_R_SPEED_REG;
+        break;
+    case 2:
+        speed_reg = FAN2_SPEED_REG;
+        break;
+    case 3:
+        speed_reg = FAN2_R_SPEED_REG;
+        break;
+    case 4:
+        speed_reg = FAN3_SPEED_REG;
+        break;
+    case 5:
+        speed_reg = FAN3_R_SPEED_REG;
+        break;
+    case 6:
+        speed_reg = FAN4_SPEED_REG;
+        break;
+    case 7:
+        speed_reg = FAN4_R_SPEED_REG;
+        break;
+    case 8:
+        speed_reg = FAN5_SPEED_REG;
+        break;
+    case 9:
+        speed_reg = FAN5_R_SPEED_REG;
+        break;
+    case 10:
+        speed_reg = FAN6_SPEED_REG;
+        break;
+    case 11:
+        speed_reg = FAN6_R_SPEED_REG;
+        break;
+    }
+
+    val = cpld_i2c_read(data, speed_reg);
+    val_rpm = (val*100);
+
+    return sprintf(buf, "%d\n", val_rpm);
+}
+
+/* ------------- */
+
+static ssize_t show_fan_led2_status(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, LED2_DISPLAY_REG);
+    val = (val >> sda->index) & 0x3;
+
+    return sprintf(buf,"%s\n",fan_led_mode_str[val]);
+}
+
+static ssize_t set_fan_led2_status(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, mask=0, usr_val=0;
+    int i;
+
+    mask = (~(0x3 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, LED2_DISPLAY_REG);
+    reg_val = reg_val & mask;
+
+    for(i=FAN_LED_BASE ; i<=FAN_LED_OFF ; i++) {
+        if(strncmp(buf, fan_led_mode_str[i],strlen(fan_led_mode_str[i]))==0) {
+            usr_val = i << sda->index;
+            cpld_i2c_write(data, LED2_DISPLAY_REG, reg_val|usr_val);
+            break;
+        }
+    }
+
+    return count;
+}
+
+/* ------------- */
+
+static ssize_t show_fan_led1_status(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, LED1_DISPLAY_REG);
+    val = (val >> sda->index) & 0x3;
+
+    return sprintf(buf,"%s\n",fan_led_mode_str[val]);
+}
+
+static ssize_t set_fan_led1_status(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, mask=0, usr_val=0;
+    int i;
+
+    mask = (~(0x3 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, LED1_DISPLAY_REG);
+    reg_val = reg_val & mask;
+
+    for(i=FAN_LED_BASE; i<= FAN_LED_OFF; i++) {
+        if(strncmp(buf, fan_led_mode_str[i],strlen(fan_led_mode_str[i]))==0) {
+            usr_val = i << sda->index;
+            cpld_i2c_write(data, LED1_DISPLAY_REG, reg_val|usr_val);
+            break;
+        }
+    }
+
+    return count;
+}
+
+/* ------------- */
+
+static ssize_t show_fan_power(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = cpld_i2c_read(data, FAN_POWER_REG);
+
+    return sprintf(buf,"%d\n",(val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_fan_power(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val=0, usr_val=0, mask;
+    int ret=kstrtou8(buf,10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, FAN_POWER_REG);
+    reg_val = reg_val & mask;
+
+    usr_val = usr_val << sda->index;
+
+    cpld_i2c_write(data, FAN_POWER_REG, (reg_val|usr_val));
+
+    return count;
+
+}
+
+// sysfs attributes
+static SENSOR_DEVICE_ATTR(board_type, S_IRUGO, show_board_type, NULL, 0);
+static SENSOR_DEVICE_ATTR(fan_version, S_IRUGO, show_fan_cpld_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(fan_reset, S_IRUGO, show_fan_cpld_reset, NULL, FAN_CPLD_RESET_BIT);
+static SENSOR_DEVICE_ATTR(fan1_present, S_IRUGO, show_fan_present, NULL, FAN1_PRES);
+static SENSOR_DEVICE_ATTR(fan2_present, S_IRUGO, show_fan_present, NULL, FAN2_PRES);
+static SENSOR_DEVICE_ATTR(fan3_present, S_IRUGO, show_fan_present, NULL, FAN3_PRES);
+static SENSOR_DEVICE_ATTR(fan4_present, S_IRUGO, show_fan_present, NULL, FAN4_PRES);
+static SENSOR_DEVICE_ATTR(fan5_present, S_IRUGO, show_fan_present, NULL, FAN5_PRES);
+static SENSOR_DEVICE_ATTR(fan6_present, S_IRUGO, show_fan_present, NULL, FAN6_PRES);
+static SENSOR_DEVICE_ATTR(fan1_direction, S_IRUGO, show_fan_direction, NULL, FAN1_PRES);
+static SENSOR_DEVICE_ATTR(fan2_direction, S_IRUGO, show_fan_direction, NULL, FAN2_PRES);
+static SENSOR_DEVICE_ATTR(fan3_direction, S_IRUGO, show_fan_direction, NULL, FAN3_PRES);
+static SENSOR_DEVICE_ATTR(fan4_direction, S_IRUGO, show_fan_direction, NULL, FAN4_PRES);
+static SENSOR_DEVICE_ATTR(fan5_direction, S_IRUGO, show_fan_direction, NULL, FAN5_PRES);
+static SENSOR_DEVICE_ATTR(fan6_direction, S_IRUGO, show_fan_direction, NULL, FAN6_PRES);
+static SENSOR_DEVICE_ATTR(fans_pwm, S_IRUGO | S_IWUSR, show_fan_pwm, set_fan_pwm, 0);
+static SENSOR_DEVICE_ATTR(fan1_speed, S_IRUGO, show_fan_speed, NULL, FAN1_ID);
+static SENSOR_DEVICE_ATTR(fan2_speed, S_IRUGO, show_fan_speed, NULL, FAN2_ID);
+static SENSOR_DEVICE_ATTR(fan3_speed, S_IRUGO, show_fan_speed, NULL, FAN3_ID);
+static SENSOR_DEVICE_ATTR(fan4_speed, S_IRUGO, show_fan_speed, NULL, FAN4_ID);
+static SENSOR_DEVICE_ATTR(fan5_speed, S_IRUGO, show_fan_speed, NULL, FAN5_ID);
+static SENSOR_DEVICE_ATTR(fan6_speed, S_IRUGO, show_fan_speed, NULL, FAN6_ID);
+static SENSOR_DEVICE_ATTR(fan7_speed, S_IRUGO, show_fan_speed, NULL, FAN7_ID);
+static SENSOR_DEVICE_ATTR(fan8_speed, S_IRUGO, show_fan_speed, NULL, FAN8_ID);
+static SENSOR_DEVICE_ATTR(fan9_speed, S_IRUGO, show_fan_speed, NULL, FAN9_ID);
+static SENSOR_DEVICE_ATTR(fan10_speed, S_IRUGO, show_fan_speed, NULL, FAN10_ID);
+static SENSOR_DEVICE_ATTR(fan11_speed, S_IRUGO, show_fan_speed, NULL, FAN11_ID);
+static SENSOR_DEVICE_ATTR(fan12_speed, S_IRUGO, show_fan_speed, NULL, FAN12_ID);
+static SENSOR_DEVICE_ATTR(fan1_led, S_IRUGO | S_IWUSR, show_fan_led2_status, set_fan_led2_status, FAN1_LED_REG);
+static SENSOR_DEVICE_ATTR(fan2_led, S_IRUGO | S_IWUSR, show_fan_led2_status, set_fan_led2_status, FAN2_LED_REG);
+static SENSOR_DEVICE_ATTR(fan3_led, S_IRUGO | S_IWUSR, show_fan_led1_status, set_fan_led1_status, FAN3_LED_REG);
+static SENSOR_DEVICE_ATTR(fan4_led, S_IRUGO | S_IWUSR, show_fan_led1_status, set_fan_led1_status, FAN4_LED_REG);
+static SENSOR_DEVICE_ATTR(fan5_led, S_IRUGO | S_IWUSR, show_fan_led1_status, set_fan_led1_status, FAN5_LED_REG);
+static SENSOR_DEVICE_ATTR(fan6_led, S_IRUGO | S_IWUSR, show_fan_led1_status, set_fan_led1_status, FAN6_LED_REG);
+static SENSOR_DEVICE_ATTR(fan1_power, S_IRUGO | S_IWUSR, show_fan_power, set_fan_power, FAN1_PRES);
+static SENSOR_DEVICE_ATTR(fan2_power, S_IRUGO | S_IWUSR, show_fan_power, set_fan_power, FAN2_PRES);
+static SENSOR_DEVICE_ATTR(fan3_power, S_IRUGO | S_IWUSR, show_fan_power, set_fan_power, FAN3_PRES);
+static SENSOR_DEVICE_ATTR(fan4_power, S_IRUGO | S_IWUSR, show_fan_power, set_fan_power, FAN4_PRES);
+static SENSOR_DEVICE_ATTR(fan5_power, S_IRUGO | S_IWUSR, show_fan_power, set_fan_power, FAN5_PRES);
+static SENSOR_DEVICE_ATTR(fan6_power, S_IRUGO | S_IWUSR, show_fan_power, set_fan_power, FAN6_PRES);
+
+
+static struct attribute *fan_cpld_attributes[] = {
+    &sensor_dev_attr_board_type.dev_attr.attr,
+    &sensor_dev_attr_fan_version.dev_attr.attr,
+    &sensor_dev_attr_fan_reset.dev_attr.attr,
+    &sensor_dev_attr_fan1_present.dev_attr.attr,
+    &sensor_dev_attr_fan2_present.dev_attr.attr,
+    &sensor_dev_attr_fan3_present.dev_attr.attr,
+    &sensor_dev_attr_fan4_present.dev_attr.attr,
+    &sensor_dev_attr_fan5_present.dev_attr.attr,
+    &sensor_dev_attr_fan6_present.dev_attr.attr,
+    &sensor_dev_attr_fan1_direction.dev_attr.attr,
+    &sensor_dev_attr_fan2_direction.dev_attr.attr,
+    &sensor_dev_attr_fan3_direction.dev_attr.attr,
+    &sensor_dev_attr_fan4_direction.dev_attr.attr,
+    &sensor_dev_attr_fan5_direction.dev_attr.attr,
+    &sensor_dev_attr_fan6_direction.dev_attr.attr,
+    &sensor_dev_attr_fans_pwm.dev_attr.attr,
+    &sensor_dev_attr_fan1_speed.dev_attr.attr,
+    &sensor_dev_attr_fan2_speed.dev_attr.attr,
+    &sensor_dev_attr_fan3_speed.dev_attr.attr,
+    &sensor_dev_attr_fan4_speed.dev_attr.attr,
+    &sensor_dev_attr_fan5_speed.dev_attr.attr,
+    &sensor_dev_attr_fan6_speed.dev_attr.attr,
+    &sensor_dev_attr_fan7_speed.dev_attr.attr,
+    &sensor_dev_attr_fan8_speed.dev_attr.attr,
+    &sensor_dev_attr_fan9_speed.dev_attr.attr,
+    &sensor_dev_attr_fan10_speed.dev_attr.attr,
+    &sensor_dev_attr_fan11_speed.dev_attr.attr,
+    &sensor_dev_attr_fan12_speed.dev_attr.attr,
+    &sensor_dev_attr_fan1_led.dev_attr.attr,
+    &sensor_dev_attr_fan2_led.dev_attr.attr,
+    &sensor_dev_attr_fan3_led.dev_attr.attr,
+    &sensor_dev_attr_fan4_led.dev_attr.attr,
+    &sensor_dev_attr_fan5_led.dev_attr.attr,
+    &sensor_dev_attr_fan6_led.dev_attr.attr,
+    &sensor_dev_attr_fan1_power.dev_attr.attr,
+    &sensor_dev_attr_fan2_power.dev_attr.attr,
+    &sensor_dev_attr_fan3_power.dev_attr.attr,
+    &sensor_dev_attr_fan4_power.dev_attr.attr,
+    &sensor_dev_attr_fan5_power.dev_attr.attr,
+    &sensor_dev_attr_fan6_power.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group fan_cpld_group = {
+    .attrs = fan_cpld_attributes,
+};
+
+static int fan_cpld_probe(struct i2c_client *client,
+        const struct i2c_device_id *dev_id)
+{
+    int status;
+     struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia FAN CPLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &fan_cpld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit;
+    }
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static void fan_cpld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &fan_cpld_group);
+    kfree(data);
+}
+
+static const struct of_device_id fan_cpld_of_ids[] = {
+    {
+        .compatible = "nokia,fan_cpld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, fan_cpld_of_ids);
+
+static const struct i2c_device_id fan_cpld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, fan_cpld_ids);
+
+static struct i2c_driver fan_cpld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(fan_cpld_of_ids),
+    },
+    .probe        = fan_cpld_probe,
+    .remove       = fan_cpld_remove,
+    .id_table     = fan_cpld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init fan_cpld_init(void)
+{
+    return i2c_add_driver(&fan_cpld_driver);
+}
+
+static void __exit fan_cpld_exit(void)
+{
+    i2c_del_driver(&fan_cpld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA FAN CPLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(fan_cpld_init);
+module_exit(fan_cpld_exit);

--- a/ixr7220d4/scripts/d4_platform_init.sh
+++ b/ixr7220d4/scripts/d4_platform_init.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# platform init script for Nokia-IXR7220-D4-36D
+
+# Load required kernel-mode drivers
+
+load_kernel_drivers() {
+    echo "Loading Kernel Drivers"
+    depmod -a
+    rmmod i2c-i801
+    modprobe i2c-i801
+    modprobe i2c-ismt
+    modprobe i2c-dev
+    modprobe i2c-mux
+    modprobe i2c-smbus
+    modprobe i2c-mux-pca954x
+    modprobe d4_cpupld
+    modprobe d4_cpld1
+    modprobe d4_cpld2
+    modprobe d4_cpld3
+    modprobe fan_cpld
+    modprobe acton_psu
+    modprobe lm75
+    modprobe at24
+    modprobe optoe
+}
+
+d4_profile()
+{
+    MAC_ADDR=$(sudo decode-syseeprom -m)
+    sed -i "s/switchMacAddress=.*/switchMacAddress=$MAC_ADDR/g" /usr/share/sonic/device/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D/profile.ini
+    echo "Nokia-IXR7220-D4-36D: Updating switch mac address ${MAC_ADDR}"
+}
+
+file_exists() {
+    # Wait 10 seconds max till file exists
+    for((i=0; i<10; i++));
+    do
+        if [ -f $1 ]; then
+            return 1
+        fi
+        sleep 1
+    done
+    return 0
+ }
+
+# Install kernel drivers required for i2c bus access
+load_kernel_drivers
+
+# Enumerate I2C Multiplexers
+echo pca9548 0x77 > /sys/bus/i2c/devices/i2c-0/new_device
+echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-2/new_device
+echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-2/new_device
+echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-20/new_device
+echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-21/new_device
+echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-22/new_device
+echo pca9546 0x73 > /sys/bus/i2c/devices/i2c-23/new_device
+echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-24/new_device
+
+# Enumerate system eeprom
+echo 24c02 0x57 > /sys/bus/i2c/devices/i2c-0/new_device
+
+#Enumerate CPLDs
+echo d4_cpupld 0x65 > /sys/bus/i2c/devices/i2c-1/new_device
+echo d4_cpld1  0x60 > /sys/bus/i2c/devices/i2c-10/new_device
+echo d4_cpld2  0x62 > /sys/bus/i2c/devices/i2c-10/new_device
+echo d4_cpld3  0x64 > /sys/bus/i2c/devices/i2c-10/new_device
+
+# Bulk operations to (un)set lp mode/reset tranceivers
+echo '0' > /sys/bus/i2c/devices/10-0060/bulk_qsfp_reset
+sleep 2
+echo '0' > /sys/bus/i2c/devices/10-0064/bulk_qsfp28_lpmod
+echo '1' > /sys/bus/i2c/devices/10-0064/bulk_qsfpdd_lpmod
+sleep 2
+echo '1' > /sys/bus/i2c/devices/10-0060/bulk_qsfp_reset
+
+# Set pca9548 idle_state as -2: MUX_IDLE_DISCONNECT
+echo -2 > /sys/bus/i2c/devices/2-0071/idle_state
+echo -2 > /sys/bus/i2c/devices/2-0072/idle_state
+echo -2 > /sys/bus/i2c/devices/20-0073/idle_state
+echo -2 > /sys/bus/i2c/devices/21-0073/idle_state
+echo -2 > /sys/bus/i2c/devices/22-0073/idle_state
+echo -2 > /sys/bus/i2c/devices/23-0073/idle_state
+echo -2 > /sys/bus/i2c/devices/24-0073/idle_state
+
+# PSU
+echo acbel_fsh082 0x58 > /sys/bus/i2c/devices/i2c-9/new_device
+echo acbel_fsh082 0x59 > /sys/bus/i2c/devices/i2c-9/new_device
+
+# FANS
+echo fan_cpld 0x66 > /sys/bus/i2c/devices/i2c-14/new_device
+
+for chan in {25..60}; do
+    echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-${chan}/new_device
+    sleep 0.1
+done
+
+file_exists /sys/bus/i2c/devices/0-0057/eeprom
+status=$?
+if [ "$status" == "1" ]; then
+    chmod 644 /sys/bus/i2c/devices/0-0057/eeprom
+    d4_profile
+else
+    echo "SYSEEPROM file not found"
+fi
+
+exit 0

--- a/ixr7220d4/service/d4_platform_init.service
+++ b/ixr7220d4/service/d4_platform_init.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nokia-IXR7220-D4-36D Platform Service
+After=sysinit.target
+Before=pmon.service determine-reboot-cause.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/d4_platform_init.sh
+StandardOutput=tty
+
+[Install]
+WantedBy=multi-user.target

--- a/ixr7220d4/setup.py
+++ b/ixr7220d4/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from setuptools import setup
+os.listdir
+
+setup(
+    name='sonic_platform',
+    version='1.0',
+    description='Module to initialize Nokia 7220 IXR D4 platforms',
+
+    packages=[        
+        'sonic_platform',
+        'sonic_platform.test'
+    ],
+      
+    package_dir={        
+        'sonic_platform': 'sonic_platform'
+    }
+)

--- a/ixr7220d4/sonic_platform/__init__.py
+++ b/ixr7220d4/sonic_platform/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["platform"]
+from sonic_platform import *

--- a/ixr7220d4/sonic_platform/chassis.py
+++ b/ixr7220d4/sonic_platform/chassis.py
@@ -1,0 +1,412 @@
+"""
+    Module contains an implementation of SONiC Platform Base API and
+    provides the platform information
+"""
+
+try:
+    import os
+    import sys
+    from sonic_platform_base.chassis_base import ChassisBase
+    from sonic_platform.sfp import Sfp
+    from sonic_platform.eeprom import Eeprom
+    from sonic_platform.fan import Fan
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+    from .fan_drawer import RealDrawer
+    from sonic_platform.psu import Psu
+    from sonic_platform.thermal import Thermal
+    from sonic_platform.component import Component
+    from sonic_platform.sfp_event import SfpEvent
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+
+QSFP_PORT_NUM = 36
+QSFP_DD_START = 28
+PORT_START    =  1
+PORT_END      = 36
+
+CPUPLD_DIR = "/sys/bus/i2c/devices/1-0065/"
+CPLD1_DIR  = "/sys/bus/i2c/devices/10-0060/"
+
+# Device counts
+FAN_DRAWERS      = 6
+FANS_PER_DRAWER  = 2
+PSU_NUM          = 2
+THERMAL_NUM      = 7
+MAX_D4_COMPONENT = 6
+MAX_SELECT_DELAY = 10
+
+sonic_logger = logger.Logger("chassis")
+sonic_logger.set_min_log_priority_info()
+
+class Chassis(ChassisBase):
+    """
+    Nokia platform-specific Chassis class
+        customized for the 7220 D4-36D platform.
+    """
+
+    def __init__(self):
+        ChassisBase.__init__(self)
+        self.system_led_supported_color = ['green', 'blue', 'green_blink',
+                                            'amber', 'off']
+
+        self._watchdog = None
+        self.sfp_event = None
+        self.max_select_event_returned = None
+
+        self.__initialize_eeprom()
+        self.__initialize_fan()
+        self.__initialize_psu()
+        self.__initialize_sfp()
+        self.__initialize_thermals()
+        self.__initialize_components()
+
+    def __initialize_eeprom(self):
+        self._eeprom = Eeprom(False, 0, False, 0)
+
+    def __initialize_fan(self):
+        for drawer_index in range(FAN_DRAWERS):
+            fandrawer = RealDrawer(drawer_index)
+            self._fan_drawer_list.append(fandrawer)
+            for fan_index in range(FANS_PER_DRAWER):
+                fan = Fan(fan_index, drawer_index)
+                fandrawer._fan_list.append(fan)
+                self._fan_list.append(fan)
+
+    def __initialize_psu(self):
+        for index in range(0, PSU_NUM):
+            psu = Psu(index)
+            self._psu_list.append(psu)
+
+    def __initialize_sfp(self):
+        for index in range(PORT_START, PORT_START + QSFP_PORT_NUM):
+            sfp_type = "QSFP28" if index <= QSFP_DD_START else "QSFPDD"
+            eeprom_path = f"/sys/bus/i2c/devices/{24+index}-0050/eeprom"
+            if not os.path.exists(eeprom_path):
+                sonic_logger.log_info(f"path {eeprom_path} does not exist")
+            sfp_node = Sfp(index, sfp_type, eeprom_path)
+            self._sfp_list.append(sfp_node)
+
+            self.sfp_event_initialized = False
+
+    def __initialize_thermals(self):
+        for index in range(0, THERMAL_NUM):
+            thermal = Thermal(index)
+            self._thermal_list.append(thermal)
+
+
+    def __initialize_components(self):
+        for index in range(0, MAX_D4_COMPONENT):
+            component = Component(index)
+            self._component_list.append(component)
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of physical SFP ports in a
+            chassis starting from 1.
+
+        Returns:
+            An object dervied from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write(f"SFP index {index} out of range (1-{len(self._sfp_list)})\n")
+        return sfp
+
+    def get_chassis_fan_type(self):
+        """
+        Retrieves the fan type (B2F, F2B) that currently is loaded into the chassis.
+        All fans should be of same type, i.e., either B2F or F2B.
+
+        Returns:
+            Airflow direction: FAN_DIRECTION_INTAKE for F2B,
+                               FAN_DIRECTION_EXHAUST for B2F,
+                               o/w, empty string "".
+        """
+        fan_type = set()
+        for fan in self._fan_list:
+            fan_type.add(fan.get_direction())
+
+        return list(fan_type)[0] if len(fan_type) == 1 else ''
+
+    def get_change_event(self, timeout=0):
+        """
+        Returns a nested dictionary containing all devices which have
+        experienced a change at chassis level
+
+        Args:
+            timeout: Timeout in milliseconds (optional). If timeout == 0,
+                this method will block until a change is detected.
+
+        Returns:
+            (bool, dict):
+                - True if call successful, False if not;
+                - A nested dictionary where key is a device type,
+                  value is a dictionary with key:value pairs in the format of
+                  {'device_id':'device_event'},
+                  where device_id is the device ID for this device and
+                        device_event,
+                             status='1' represents device inserted,
+                             status='0' represents device removed.
+                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
+                      indicates that fan 0 has been removed, fan 2
+                      has been inserted and sfp 11 has been removed.
+        """
+        # Initialize SFP event first
+        if not self.sfp_event_initialized:
+            self.sfp_event = SfpEvent()
+            self.sfp_event.initialize()
+            self.max_select_event_returned = PORT_END
+            self.sfp_event_initialized = True
+
+        wait_for_ever = timeout == 0
+        port_dict = {}
+
+        if wait_for_ever:
+            # xcrvd will call this monitor loop in the "SYSTEM_READY" state
+            # sonic_logger.log_info(" wait_for_ever get_change_event %d" % timeout)
+            timeout = MAX_SELECT_DELAY
+            while True:
+                status = self.sfp_event.check_sfp_status(port_dict, timeout)
+                if port_dict:
+                    break
+        else:
+            # At boot up and in "INIT" state call from xrcvd will have timeout
+            # value return true without change after timeout and will
+            # transition to "SYSTEM_READY"
+            status = self.sfp_event.check_sfp_status(port_dict, timeout)
+
+        if status:
+            return True, {'sfp': port_dict}
+        return True, {'sfp': {}}
+
+    def get_num_psus(self):
+        """
+        Retrieves the num of the psus
+        Returns:
+            int: The num of the psus
+        """
+        return PSU_NUM
+
+    def get_name(self):
+        """
+        Retrieves the name of the chassis
+        Returns:
+            string: The name of the chassis
+        """
+        return self._eeprom.modelstr()
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the chassis
+        Returns:
+            bool: True if chassis is present, False if not
+        """
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the chassis
+        Returns:
+            string: Model/part number of chassis
+        """
+        return self._eeprom.part_number_str()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the chassis
+        Returns:
+            string: Serial number of chassis
+        """
+        return self._eeprom.serial_number_str()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the chassis
+        Returns:
+            bool: A boolean value, True if chassis is operating properly
+            False if not
+        """
+        return True
+
+    def get_base_mac(self):
+        """
+        Retrieves the base MAC address for the chassis
+
+        Returns:
+            A string containing the MAC address in the format
+            'XX:XX:XX:XX:XX:XX'
+        """
+        return self._eeprom.base_mac_addr()
+
+    def get_service_tag(self):
+        """
+        Retrieves the Service Tag of the chassis
+        Returns:
+            string: Service Tag of chassis
+        """
+        return self._eeprom.service_tag_str()
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the chassis
+
+        Returns:
+            string: Revision value of chassis
+        """
+        result = read_sysfs_file(CPLD1_DIR + "pcb_ver")
+        return result[4:]
+
+    def get_system_eeprom_info(self):
+        """
+        Retrieves the full content of system EEPROM information for the
+        chassis
+
+        Returns:
+            A dictionary where keys are the type code defined in
+            OCP ONIE TlvInfo EEPROM format and values are their
+            corresponding values.
+        """
+        return self._eeprom.system_eeprom_info()
+
+    def get_thermal_manager(self):
+        """
+        Get thermal manager
+
+        Returns:
+            ThermalManager
+        """
+        from .thermal_manager import ThermalManager
+        return ThermalManager
+
+    def initizalize_system_led(self):
+        """
+        Initizalize system led
+
+        Returns:
+        bool: True if it is successful.
+        """
+        return True
+
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
+        Returns:
+            A tuple (string, string) where the first element is a string
+            containing the cause of the previous reboot. This string must be
+            one of the predefined strings in this class. If the first string
+            is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+            to pass a description of the reboot cause.
+        """
+
+        result = read_sysfs_file(CPUPLD_DIR + "reset_cause")
+
+        if (int(result, 16) & 0x20) >> 5 == 1:
+            return (self.REBOOT_CAUSE_WATCHDOG, "TCO_WDT")
+
+        if (int(result, 16) & 0x10) >> 4 == 1:
+            return (self.REBOOT_CAUSE_HARDWARE_BUTTON, "Push button")
+
+        if (int(result, 16) & 0x08) >> 3 == 1:
+            return (self.REBOOT_CAUSE_HARDWARE_OTHER, "Cold Reset")
+
+        if (int(result, 16) & 0x04) >> 2 == 1:
+            return (self.REBOOT_CAUSE_HARDWARE_OTHER, "Manu Reset")
+
+        if (int(result, 16) & 0x01) == 1:
+            return (self.REBOOT_CAUSE_WATCHDOG, "CPU_WDT")
+
+        return (self.REBOOT_CAUSE_NON_HARDWARE, None)
+
+    def get_watchdog(self):
+        """
+        Retrieves hardware watchdog device on this chassis
+
+        Returns:
+            An object derived from WatchdogBase representing the hardware
+            watchdog device
+
+        Note:
+            We overload this method to ensure that watchdog is only initialized
+            when it is referenced. Currently, only one daemon can open the
+            watchdog. To initialize watchdog in the constructor causes multiple
+            daemon try opening watchdog when loading and constructing a chassis
+            object and fail. By doing so we can eliminate that risk.
+        """
+        try:
+            if self._watchdog is None:
+                from sonic_platform.watchdog import WatchdogImplBase
+                watchdog_device_path = "/dev/watchdog0"
+                self._watchdog = WatchdogImplBase(watchdog_device_path)
+        except ImportError as e:
+            sonic_logger.log_warning(f"Fail to load watchdog {repr(e)}")
+
+        return self._watchdog
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent
+        cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0',
+        then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if
+            cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the system LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   system LED
+
+        Returns:
+            bool: True if system LED state is set successfully, False if not
+        """
+        try:
+            reversed_led_support = list(reversed(self.system_led_supported_color))
+            idx = reversed_led_support.index(color)
+            if idx == 0:
+                write_sysfs_file(CPLD1_DIR + 'sys_led', '0')
+            else:
+                write_sysfs_file(CPLD1_DIR + 'sys_led', str(2**(idx-1)))
+            return True
+        except ValueError:
+            return False
+
+    def get_status_led(self):
+        """
+        Gets the state of the system LED
+
+        Returns:
+            A string, one of the valid LED color strings which could be vendor
+            specified.
+        """
+        result = read_sysfs_file(CPLD1_DIR + 'sys_led')
+        result = int(result, 16)
+        if result == 0:
+            return 'off'
+
+        for shift in list(range(0, 4)):
+            if result & (0x8 >> shift):
+                return self.system_led_supported_color[shift]
+        return 'N/A'

--- a/ixr7220d4/sonic_platform/component.py
+++ b/ixr7220d4/sonic_platform/component.py
@@ -1,0 +1,201 @@
+"""
+    NOKIA IXR7220-D4
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Components' (e.g., BIOS, CPLD, etc.) available in
+    the platform
+"""
+
+try:
+    import os
+    import subprocess
+    import ntpath
+    from sonic_platform_base.component_base import ComponentBase
+    from sonic_platform.sysfs import read_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+SYSFS_PATH = ["/sys/class/dmi/id/bios_version",
+              "/sys/bus/i2c/devices/1-0065/cpld_ver",
+              "/sys/bus/i2c/devices/10-0060/cpld_ver",
+              "/sys/bus/i2c/devices/10-0062/cpld_ver",
+              "/sys/bus/i2c/devices/10-0064/cpld_ver",
+              "/sys/bus/i2c/devices/14-0066/fan_version"]
+
+class Component(ComponentBase):
+    """Nokia platform-specific Component class"""
+
+    CHASSIS_COMPONENTS = [
+        ["BIOS", "Basic Input/Output System"],
+        ["CPUPLD", "Used for managing CPU board "],
+        ["SWPLD1", "Used for managing QSFP28, QSFPDD, and System LEDs "],
+        ["SWPLD2", "Used for managing QSFP28 19-28 and QSFPDD 29-36 port status, module presence and loopback mode "],
+        ["SWPLD3", "Used for managing QSFP28 1-18 port status, module presence and loopback mode "],
+        ["FANPLD", "Used for managing FAN board "]]
+
+    CPLD_UPDATE_COMMAND = ['./cpldupd_d4', '-u', '', '']
+    BIOS_UPDATE_COMMAND = ['./afulnx_64', '', '/P', '/B', '/N', '/K', '/ME', '/RLC:F']
+
+    def __init__(self, component_index):
+        self.index = component_index
+        self.name = self.CHASSIS_COMPONENTS[self.index][0]
+        self.description = self.CHASSIS_COMPONENTS[self.index][1]
+        self.sysfs_file = SYSFS_PATH[self.index]
+
+
+    def _get_cpld_version(self):
+        return read_sysfs_file(self.sysfs_file)
+
+    def get_name(self):
+        """
+        Retrieves the name of the component
+
+        Returns:
+            A string containing the name of the component
+        """
+        return self.name
+
+    def get_model(self):
+        """
+        Retrieves the part number of the component
+        Returns:
+            string: Part number of component
+        """
+        return 'NA'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the component
+        Returns:
+            string: Serial number of component
+        """
+        return 'NA'
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the component
+        Returns:
+            bool: True if  present, False if not
+        """
+        return True
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the component
+        Returns:
+            bool: True if component is operating properly, False if not
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        Returns:
+            integer: The 1-based relative physical position in parent
+            device or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether component is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+
+        Returns:
+            A string containing the description of the component
+        """
+        return self.description
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of the component
+
+        Returns:
+            A string containing the firmware version of the component
+        """
+        return self._get_cpld_version()
+
+    def install_firmware(self, image_path):
+        """
+        Installs firmware to the component
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A boolean, True if install was successful, False if not
+        """
+        image_name = ntpath.basename(image_path)
+        print(f"IXR-7220-D4 - Install image {image_name} for component {self.get_name()}")
+
+        # check whether the image file exists
+        os.chdir("/tmp")
+        if not os.path.isfile(image_name):
+            print(f"ERROR: the image {image_name} doesn't exist in /tmp")
+            return False
+
+        # check whether the upgrade tool exists
+        if self.name == "BIOS":
+            if not os.path.isfile('/tmp/afulnx_64'):
+                print("ERROR: the BIOS upgrade tool /tmp/afulnx_64 doesn't exist ")
+                return False
+            self.BIOS_UPDATE_COMMAND[1] = image_name
+            UPDATE_CMD = self.BIOS_UPDATE_COMMAND
+        else:
+            if not os.path.isfile('/tmp/cpldupd_d4'):
+                print("ERROR: the CPLD upgrade tool /tmp/cpldupd_d4 doesn't exist ")
+                return False
+            if self.get_name() == "FANPLD":
+                self.CPLD_UPDATE_COMMAND[2] = "FAN_CPLD"
+            elif self.get_name() == "CPUPLD":
+                self.CPLD_UPDATE_COMMAND[2] = "CPU_CPLD"
+            else:
+                self.CPLD_UPDATE_COMMAND[2] = "MAIN_CPLD"
+            self.CPLD_UPDATE_COMMAND[3] = image_name
+            UPDATE_CMD = self.CPLD_UPDATE_COMMAND
+
+        try:
+            subprocess.run(UPDATE_CMD, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            print(f"ERROR: Failed to upgrade {self.get_name()}: rc={e.returncode}")
+        print(f"\n{self.get_name()} upgraded!\n")
+        return True
+
+    def update_firmware(self, _image_path):
+        """
+        Updates firmware of the component
+
+        This API performs firmware update:
+        it assumes firmware installation and loading in a single call.
+        In case platform component requires some extra steps (apart from calling Low Level Utility)
+        to load the installed firmware (e.g, reboot, power cycle, etc.)
+        - this will be done automatically by API
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Raises:
+            RuntimeError: update failed
+        """
+        return False
+
+    def get_available_firmware_version(self, _image_path):
+        """
+        Retrieves the available firmware version of the component
+
+        Note: the firmware version will be read from image
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A string containing the available firmware version of the component
+        """
+        return "N/A"

--- a/ixr7220d4/sonic_platform/eeprom.py
+++ b/ixr7220d4/sonic_platform/eeprom.py
@@ -1,0 +1,182 @@
+"""
+    Nokia 7220 IXR D4
+
+    Module contains platform specific implementation of SONiC Platform
+    Base API and provides the EEPROMs' information.
+
+    The different EEPROMs available are as follows:
+    - System EEPROM : Contains Serial number, Service tag, Base MA
+                      address, etc. in ONIE TlvInfo EEPROM format.
+"""
+
+try:
+    import os
+    from sonic_platform_base.sonic_eeprom.eeprom_tlvinfo import TlvInfoDecoder
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+sonic_logger = logger.Logger('eeprom')
+sonic_logger.set_min_log_priority_info()
+
+class Eeprom(TlvInfoDecoder):
+    """Nokia platform-specific EEPROM class"""
+
+    I2C_DIR = "/sys/bus/i2c/devices/"
+
+    def __init__(self, is_psu, psu_index, is_fan, drawer_index):
+        self.is_psu_eeprom = is_psu
+        self.is_fan_eeprom = is_fan
+        self.is_sys_eeprom = not (is_psu | is_fan)
+
+        if self.is_sys_eeprom:
+            self.start_offset = 0
+            self.eeprom_path = self.I2C_DIR + "0-0057/eeprom"
+            # System EEPROM is in ONIE TlvInfo EEPROM format
+            super(Eeprom, self).__init__(self.eeprom_path, self.start_offset, '', True)
+            self.base_mac = ''
+            self.serial_number = ''
+            self.part_number = ''
+            self.model_str = ''
+            self.service_tag = ''
+
+        elif self.is_psu_eeprom:
+            self.start_offset = 0
+            self.serial_number = ''
+            self.part_number = ''
+            self.model_str = ''
+            self.service_tag = 'NA'
+
+    def _load_system_eeprom(self):
+        """
+        Reads the system EEPROM and retrieves the values corresponding
+        to the codes defined as per ONIE TlvInfo EEPROM format and fills
+        them in a dictionary.
+        """
+        try:
+            # Read System EEPROM as per ONIE TlvInfo EEPROM format.
+            self.eeprom_data = self.read_eeprom()
+        except Exception as e:
+            sonic_logger.log_warning("Unable to read system eeprom")
+            self.base_mac = 'NA'
+            self.serial_number = 'NA'
+            self.part_number = 'NA'
+            self.model_str = 'NA'
+            self.service_tag = 'NA'
+            self.eeprom_tlv_dict = dict()
+        else:
+            eeprom = self.eeprom_data
+            self.eeprom_tlv_dict = dict()
+
+            if not self.is_valid_tlvinfo_header(eeprom):
+                sonic_logger.log_warning("Invalid system eeprom TLV header")
+                self.base_mac = 'NA'
+                self.serial_number = 'NA'
+                self.part_number = 'NA'
+                self.model_str = 'NA'
+                self.service_tag = 'NA'
+                return
+
+            total_length = (eeprom[9] << 8) | eeprom[10]
+            tlv_index = self._TLV_INFO_HDR_LEN
+            tlv_end = self._TLV_INFO_HDR_LEN + total_length
+
+            while (tlv_index + 2) < len(eeprom) and tlv_index < tlv_end:
+                if not self.is_valid_tlv(eeprom[tlv_index:]):
+                    break
+
+                tlv = eeprom[tlv_index:tlv_index + 2
+                             + eeprom[tlv_index + 1]]
+                code = "0x%02X" % (tlv[0])
+
+                name, value = self.decoder(None, tlv)
+
+                self.eeprom_tlv_dict[code] = value
+                if eeprom[tlv_index] == self._TLV_CODE_CRC_32:
+                    break
+
+                tlv_index += eeprom[tlv_index+1] + 2
+
+            self.base_mac = self.eeprom_tlv_dict.get(
+                "0x%X" % (self._TLV_CODE_MAC_BASE), 'NA')
+            self.serial_number = self.eeprom_tlv_dict.get(
+                "0x%X" % (self._TLV_CODE_SERIAL_NUMBER), 'NA')
+            self.part_number = self.eeprom_tlv_dict.get(
+                "0x%X" % (self._TLV_CODE_PART_NUMBER), 'NA')
+            self.model_str = self.eeprom_tlv_dict.get(
+                "0x%X" % (self._TLV_CODE_PRODUCT_NAME), 'NA')
+            self.service_tag = self.eeprom_tlv_dict.get(
+                "0x%X" % (self._TLV_CODE_SERVICE_TAG), 'NA')
+
+    def _get_eeprom_field(self, field_name):
+        """
+        For a field name specified in the EEPROM format, returns the
+        presence of the field and the value for the same.
+        """
+        field_start = 0
+        for field in self.format:
+            field_end = field_start + field[2]
+            if field[0] == field_name:
+                return (True, self.eeprom_data[field_start:field_end])
+            field_start = field_end
+
+        return (False, None)
+
+    def serial_number_str(self):
+        """
+        Returns the serial number.
+        """
+        if not self.serial_number:
+            self._load_system_eeprom()
+
+        return self.serial_number
+
+    def part_number_str(self):
+        """
+        Returns the part number.
+        """
+        if not self.part_number:
+            self._load_system_eeprom()
+
+        return self.part_number
+
+    def airflow_fan_type(self):
+        """
+        Returns the airflow fan type.
+        """
+        if self.is_psu_eeprom:
+            return int(self.psu_type.encode('hex'), 16)
+        if self.is_fan_eeprom:
+            return int(self.fan_type.encode('hex'), 16)
+
+    def base_mac_addr(self):
+        """
+        Returns the base MAC address found in the system EEPROM.
+        """
+        if not self.base_mac:
+            self._load_system_eeprom()
+
+        return self.base_mac
+
+    def modelstr(self):
+        """
+        Returns the Model name.
+        """
+        if not self.model_str:
+            self._load_system_eeprom()
+
+        return self.model_str
+
+    def service_tag_str(self):
+        """
+        Returns the servicetag number.
+        """
+        return self.service_tag
+
+    def system_eeprom_info(self):
+        """
+        Returns a dictionary, where keys are the type code defined in
+        ONIE EEPROM format and values are their corresponding values
+        found in the system EEPROM.
+        """
+        return self.eeprom_tlv_dict

--- a/ixr7220d4/sonic_platform/fan.py
+++ b/ixr7220d4/sonic_platform/fan.py
@@ -1,0 +1,329 @@
+"""
+    Nokia IXR7220 D4
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Fans' information which are available in the platform
+"""
+
+try:
+    from sonic_platform_base.fan_base import FanBase
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+FAN_PN_F2B = "3HE17744AA"
+FAN_PN_B2F = "3HE17745AA"
+FANS_PER_DRAWER = 2
+MAX_FAN_F2B_F_SPEED = 30900/FANS_PER_DRAWER
+MAX_FAN_F2B_R_SPEED = 24900/FANS_PER_DRAWER
+MAX_FAN_B2F_F_SPEED = 31000/FANS_PER_DRAWER
+MAX_FAN_B2F_R_SPEED = 25000/FANS_PER_DRAWER
+WORKING_IXR7220_F_FAN_SPEED = 3000/FANS_PER_DRAWER
+WORKING_IXR7220_R_FAN_SPEED = 2400/FANS_PER_DRAWER
+FAN_TOLERANCE   = 10
+
+
+I2C_DIR = "/sys/bus/i2c/devices/i2c-14/14-0066/"
+
+sonic_logger = logger.Logger('fan')
+
+class Fan(FanBase):
+    """Nokia platform-specific Fan class"""
+
+    def __init__(self, fan_index, drawer_index, psu_fan=False, dependency=None):
+        self.is_psu_fan = psu_fan
+
+        if not self.is_psu_fan:
+            # Fan is 1-based in Nokia platforms
+            self.index = drawer_index * FANS_PER_DRAWER + fan_index + 1
+            self.drawer_index = drawer_index + 1
+            self.get_fan_direction = I2C_DIR + f"fan{self.drawer_index}_direction"
+            self.set_fan_speed_reg = I2C_DIR + "fans_pwm"
+            self.get_fan_speed_reg = I2C_DIR + f"fan{self.index}_speed"
+            self.fan_presence_reg = I2C_DIR + f"fan{self.drawer_index}_present"
+            self.fan_led_reg = I2C_DIR + f"fan{self.drawer_index}_led"
+
+            if fan_index == 0:
+                    self.working_fan_speed = WORKING_IXR7220_F_FAN_SPEED
+                    if self.get_direction() == self.FAN_DIRECTION_INTAKE:
+                        self.max_fan_speed = MAX_FAN_F2B_F_SPEED
+                    else:
+                        self.max_fan_speed = MAX_FAN_B2F_F_SPEED
+            else:
+                    self.working_fan_speed = WORKING_IXR7220_R_FAN_SPEED
+                    if self.get_direction() == self.FAN_DIRECTION_INTAKE:
+                        self.max_fan_speed = MAX_FAN_F2B_R_SPEED
+                    else:
+                        self.max_fan_speed = MAX_FAN_B2F_R_SPEED
+        else:
+            # this is a PSU Fan
+            self.index = fan_index
+            self.dependency = dependency
+
+    def get_name(self):
+        """
+        Retrieves the name of the Fan
+
+        Returns:
+            string: The name of the Fan
+        """
+        if not self.is_psu_fan:
+            return f"Fan{self.index}"
+        return f"PSU{self.index} Fan"
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the Fan Unit
+
+        Returns:
+            bool: True if Fan is present, False if not
+        """
+        result = read_sysfs_file(self.fan_presence_reg)
+        if result == '1':
+            return True
+        return False
+
+    def get_model(self):
+        """
+        Retrieves the model number of the Fan
+
+        Returns:
+            string: Model number of Fan. Use part number for this.
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the Fan
+
+        Returns:
+            string: Serial number of Fan
+        """
+        return 'N/A'
+
+    def get_part_number(self):
+        """
+        Retrieves the part number of the Fan
+
+        Returns:
+            string: Part number of Fan
+        """
+        return FAN_PN_F2B if self.get_direction()== self.FAN_DIRECTION_INTAKE else FAN_PN_B2F
+
+    def get_service_tag(self):
+        """
+        Retrieves the service tag of the Fan
+
+        Returns:
+            string: Service Tag of Fan
+        """
+        return 'N/A'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the Fan
+
+        Returns:
+            bool: True if Fan is operating properly, False if not
+        """
+        status = False
+
+        fan_speed = read_sysfs_file(self.get_fan_speed_reg)
+        if fan_speed != 'ERR':
+            status = True if int(fan_speed) > self.working_fan_speed else False
+
+        return status
+
+    def get_direction(self):
+        """
+        Retrieves the fan airflow direction
+        Possible fan directions (relative to port-side of device)
+        Returns:
+            A string, either FAN_DIRECTION_INTAKE or
+            FAN_DIRECTION_EXHAUST depending on fan direction
+        """
+
+        direction = read_sysfs_file(self.get_fan_direction)
+        if direction != 'ERR':
+            return self.FAN_DIRECTION_INTAKE if int(direction) == 1 else self.FAN_DIRECTION_EXHAUST
+        return 'N/A'
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self.index
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
+
+    def get_speed(self):
+        """
+        Retrieves the speed of fan as a percentage of full speed
+
+        Returns:
+            An integer, the percentage of full fan speed, in the range 0 (off)
+                 to 100 (full speed)
+        """
+        fan_speed = read_sysfs_file(self.get_fan_speed_reg)
+        if fan_speed != 'ERR':
+            speed_in_rpm = int(fan_speed)*100
+        else:
+            speed_in_rpm = 0
+
+        speed = speed_in_rpm//self.max_fan_speed
+        speed = min(speed, 100)
+        return int(speed)
+
+    def get_speed_tolerance(self):
+        """
+        Retrieves the speed tolerance of the fan
+
+        Returns:
+            An integer, the percentage of variance from target speed
+            which is considered tolerable
+        """
+        return FAN_TOLERANCE
+
+    def set_speed(self, speed):
+        """
+        Set fan speed to expected value
+        Args:
+            speed: An integer, the percentage of full fan speed to set
+            fan to, in the range 0 (off) to 100 (full speed)
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        if self.is_psu_fan:
+            return False
+
+        if self.get_direction() == self.FAN_DIRECTION_INTAKE:
+            speed_to_duty = {
+                range(0, 31): 0x0,
+                range(31, 42): 0x4,
+                range(42, 47): 0x5,
+                range(47, 53): 0x6,
+                range(53, 59): 0x7,
+                range(59, 65): 0x8,
+                range(65, 70): 0x9,
+                range(70, 76): 0xA,
+                range(76, 82): 0xB,
+                range(82, 90): 0xC,
+                range(90, 94): 0xD,
+                range(94, 99): 0xE,
+                range(99, 101): 0xF
+            }
+        else:
+            speed_to_duty = {
+                range(0, 31): 0x0,
+                range(31, 42): 0x4,
+                range(42, 47): 0x5,
+                range(47, 54): 0x6,
+                range(54, 59): 0x7,
+                range(59, 65): 0x8,
+                range(65, 71): 0x9,
+                range(71, 77): 0xA,
+                range(77, 83): 0xB,
+                range(83, 88): 0xC,
+                range(88, 95): 0xD,
+                range(95, 99): 0xE,
+                range(99, 101): 0xF
+            }
+
+        fan_duty_cycle = None
+
+        for speed_range, duty in speed_to_duty.items():
+            if speed in speed_range:
+                fan_duty_cycle = duty
+                break
+
+        if fan_duty_cycle is not None:
+            if write_sysfs_file(self.set_fan_speed_reg, str(fan_duty_cycle)) != 'ERR':
+                return True
+        return False
+
+    def set_status_led(self, _color):
+        """
+        Set led to expected color
+        Args:
+            color: A string representing the color with which to set the
+                   fan module status LED
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        return False
+
+    def get_status_led(self):
+        """
+        Gets the state of the fan drawer status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        if not self.get_presence():
+            return self.STATUS_LED_COLOR_OFF
+
+        result = read_sysfs_file(self.fan_led_reg)
+
+        if result in {"base", "off"}:
+            return self.STATUS_LED_COLOR_OFF
+        if result == "green":
+            return self.STATUS_LED_COLOR_GREEN
+        if result == "red":
+            return self.STATUS_LED_COLOR_RED
+        return 'N/A'
+
+    def get_target_speed(self):
+        """
+        Retrieves the target (expected) speed of the fan
+
+        Returns:
+            An integer, the percentage of full fan speed, in the range 0
+            (off) to 100 (full speed)
+        """
+        if self.get_direction() == self.FAN_DIRECTION_INTAKE:
+            duty_to_speed = {
+                0x0: 25,
+                0x4: 36,
+                0x5: 45,
+                0x6: 50,
+                0x7: 56,
+                0x8: 62,
+                0x9: 67,
+                0xA: 73,
+                0xB: 79,
+                0xC: 86,
+                0xD: 92,
+                0xE: 96,
+                0xF: 100
+            }
+        else:
+            duty_to_speed = {
+                0x0: 25,
+                0x4: 36,
+                0x5: 45,
+                0x6: 50,
+                0x7: 56,
+                0x8: 62,
+                0x9: 68,
+                0xA: 74,
+                0xB: 80,
+                0xC: 85,
+                0xD: 91,
+                0xE: 96,
+                0xF: 100
+            }
+
+        fan_duty = read_sysfs_file(self.set_fan_speed_reg)
+        if fan_duty != 'ERR':
+            dutyspeed = int(fan_duty)
+            return duty_to_speed.get(dutyspeed, 0)
+        return 0

--- a/ixr7220d4/sonic_platform/fan_drawer.py
+++ b/ixr7220d4/sonic_platform/fan_drawer.py
@@ -1,0 +1,154 @@
+"""
+    Nokia IXR7220 D4
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Fan Drawer status which is available in the platform
+"""
+
+try:
+    from sonic_platform.sysfs import write_sysfs_file
+    from sonic_platform.eeprom import Eeprom
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+FANS_PER_DRAWER = 2
+I2C_DIR = "/sys/bus/i2c/devices/i2c-14/14-0066/"
+sonic_logger = logger.Logger(FanDrawerBase.DEVICE_TYPE)
+
+class NokiaFanDrawer(FanDrawerBase):
+    """
+    Nokia platform-specific NokiaFanDrawer class
+    """
+    def __init__(self, index):
+        super(NokiaFanDrawer, self).__init__()
+        self._index = index + 1
+        self.fan_led_color = [self.STATUS_LED_COLOR_OFF,
+                              self.STATUS_LED_COLOR_RED,
+                              self.STATUS_LED_COLOR_GREEN]
+        self.fan_led_reg = I2C_DIR + f"fan{self._index}_led"
+
+    def get_index(self):
+        """
+        Retrieves the index of the Fan Drawer
+        Returns:
+            int: the Fan Drawer's index
+        """
+        return self._index
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the Fan Drawer
+        Returns:
+            bool: return True if the Fan Drawer is present
+        """
+        return self._fan_list[0].get_presence()
+
+    def get_model(self):
+        """
+        Retrieves the model number of the Fan Drawer
+        Returns:
+            string: Part number of Fan Drawer
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the Fan Drawer
+        Returns:
+            string: Serial number of Fan
+        """
+        return 'N/A'
+
+    def get_part_number(self):
+        """
+        Retrieves the part number of the Fan Drawer
+
+        Returns:
+            string: Part number of Fan
+        """
+        return self._fan_list[0].get_part_number()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the Fan Drawer
+        Returns:
+            bool: True if Fan is operating properly, False if not
+        """
+        good_fan = 0
+        for fan in self._fan_list:
+            if fan.get_status():
+                good_fan = good_fan + 1
+
+        if good_fan == FANS_PER_DRAWER:
+            return True
+        return False
+
+    def get_direction(self):
+        """
+        Retrieves the direction of the Fan Drawer
+        Returns:
+            string: direction string
+        """
+        return self._fan_list[0].get_direction()
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the fan drawer status LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   fan drawer status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if not
+        """
+        if not self.get_presence():
+            return False
+        if color not in self.fan_led_color:
+            return False
+
+        rv = write_sysfs_file(self.fan_led_reg, color)
+        if rv != 'ERR':
+            return True
+        return False
+
+    def get_status_led(self):
+        """
+        Gets the state of the fan drawer LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings
+        """
+        return self._fan_list[0].get_status_led()
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self._index
+
+class RealDrawer(NokiaFanDrawer):
+    """
+    For Nokia platforms with fan drawer(s)
+    """
+    def __init__(self, index):
+        super().__init__(index)
+        self._name = f'drawer{self._index}'
+
+    def get_name(self):
+        """
+        return module name
+        """
+        return self._name

--- a/ixr7220d4/sonic_platform/platform.py
+++ b/ixr7220d4/sonic_platform/platform.py
@@ -1,0 +1,20 @@
+"""
+    Module contains an implementation of SONiC Platform Base API and
+    provides the platform information
+"""
+
+try:
+    from sonic_platform_base.platform_base import PlatformBase
+    from sonic_platform.chassis import Chassis
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+
+class Platform(PlatformBase):
+    """
+    Nokia platform-specific class
+    """
+
+    def __init__(self):
+        PlatformBase.__init__(self)
+        self._chassis = Chassis()

--- a/ixr7220d4/sonic_platform/psu.py
+++ b/ixr7220d4/sonic_platform/psu.py
@@ -1,0 +1,330 @@
+"""
+    Nokia IXR7220 D4-36D
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the PSUs' information which are available in the platform
+"""
+
+try:
+    import os
+    import subprocess
+    from sonic_platform.sysfs import read_sysfs_file
+    from sonic_platform_base.psu_base import PsuBase
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+PSU_NUM = 2
+PSU_DIR = ["/sys/bus/i2c/devices/9-0059/",
+           "/sys/bus/i2c/devices/9-0058/"]
+REG_DIR = "/sys/bus/i2c/devices/10-0060/"
+PSU_EEPROM_I2C = [["9", "51"],
+                  ["9", "50"]]
+
+PSU_OUTPUT_VOLTAGE_MIN = 11 * 1000
+PSU_OUTPUT_VOLTAGE_MAX = 14 * 1000
+
+sonic_logger = logger.Logger(PsuBase.DEVICE_TYPE)
+sonic_logger.set_min_log_priority_error()
+
+class Psu(PsuBase):
+    """Nokia platform-specific PSU class for 7220 D4-36D """
+
+    def __init__(self, psu_index):
+        PsuBase.__init__(self)
+        # PSU is 1-based in Nokia platforms
+        self.index = psu_index + 1
+        self._fan_list = []
+        self.psu_dir = PSU_DIR[psu_index]
+        self.eeprom = None
+
+    def _read_bin_file(self, sysfs_file, length):
+        """
+        On successful read, returns the value read from given
+        sysfs file and on failure returns ERR
+        """
+        rv = 'ERR'
+
+        try:
+            with open(sysfs_file, 'rb') as fd:
+                rv = fd.read(length)
+                fd.close()
+        except FileNotFoundError:
+            print(f"Error: {sysfs_file} doesn't exist.")
+        except PermissionError:
+            print(f"Error: Permission denied when reading file {sysfs_file}.")
+        except IOError:
+            print(f"IOError: An error occurred while reading file {sysfs_file}.")
+        return rv
+
+    def _get_active_psus(self):
+        """
+        Retrieves the operational status of the PSU and
+        calculates number of active PSU's
+
+        Returns:
+            Integer: Number of active PSU's
+        """
+        active_psus = 0
+
+        for i in range(PSU_NUM):
+            result = read_sysfs_file(REG_DIR+f"psu{i+1}_pwr_ok")
+            if result == '1':
+                active_psus = active_psus + 1
+
+        return active_psus
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+
+        Returns:
+            string: The name of the device
+        """
+        return f"PSU{self.index}"
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the Power Supply Unit (PSU)
+
+        Returns:
+            bool: True if PSU is present, False if not
+        """
+        result = read_sysfs_file(REG_DIR + f"psu{self.index}_present")
+
+        eeprom_path = f"/sys/bus/i2c/devices/{PSU_EEPROM_I2C[self.index-1][0]}-00{PSU_EEPROM_I2C[self.index-1][1]}/eeprom"
+        if result == '0':
+            if not os.path.exists(eeprom_path):
+                i2c_address = f"0x{PSU_EEPROM_I2C[self.index-1][1]}"
+                if os.path.exists(f"/sys/bus/i2c/devices/{PSU_EEPROM_I2C[self.index-1][0]}-00{PSU_EEPROM_I2C[self.index-1][1]}"):
+                    i2c_file = f"/sys/bus/i2c/devices/i2c-{PSU_EEPROM_I2C[self.index-1][0]}/delete_device"
+                    os.system(f"echo {i2c_address} > {i2c_file}")
+                i2c_file = f"/sys/bus/i2c/devices/i2c-{PSU_EEPROM_I2C[self.index-1][0]}/new_device"
+                os.system(f"echo 24c02 {i2c_address} > {i2c_file}")
+            return True
+        else:
+            if os.path.exists(eeprom_path):
+                i2c_address = f"0x{PSU_EEPROM_I2C[self.index-1][1]}"
+                i2c_file = f"/sys/bus/i2c/devices/i2c-{PSU_EEPROM_I2C[self.index-1][0]}/delete_device"
+                os.system(f"echo {i2c_address} > {i2c_file}")
+
+        return False
+
+    def get_model(self):
+        """
+        Retrieves the part number of the PSU
+
+        Returns:
+            string: Part number of PSU
+        """
+        if self.get_presence():
+            if self.eeprom is None:
+                try:
+                    eeprom_path = f"/sys/bus/i2c/devices/{PSU_EEPROM_I2C[self.index-1][0]}-00{PSU_EEPROM_I2C[self.index-1][1]}/eeprom"
+                    subprocess.run(["chmod", "644", eeprom_path], stderr=subprocess.STDOUT)
+                    self.eeprom = self._read_bin_file(eeprom_path, 256)
+                except:
+                    return 'N/A'
+            return self.eeprom[12:20].decode()
+
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the PSU
+
+        Returns:
+            string: Serial number of PSU
+        """
+        if self.get_presence():
+            if self.eeprom is None:
+                try:
+                    eeprom_path = f"/sys/bus/i2c/devices/{PSU_EEPROM_I2C[self.index-1][0]}-00{PSU_EEPROM_I2C[self.index-1][1]}/eeprom"
+                    subprocess.run(["chmod", "644", eeprom_path], stderr=subprocess.STDOUT)
+                    self.eeprom = self._read_bin_file(eeprom_path, 256)
+                except:
+                    return 'N/A'
+            return self.eeprom[88:99].decode()
+
+        return 'N/A'
+
+    def get_revision(self):
+        """
+        Retrieves the HW revision of the PSU
+
+        Returns:
+            string: HW revision of PSU
+        """
+        return 'N/A'
+
+    def get_part_number(self):
+        """
+        Retrieves the part number of the PSU
+
+        Returns:
+            string: Part number of PSU
+        """
+        if self.get_presence():
+            if self.eeprom is None:
+                try:
+                    eeprom_path = f"/sys/bus/i2c/devices/{PSU_EEPROM_I2C[self.index-1][0]}-00{PSU_EEPROM_I2C[self.index-1][1]}/eeprom"
+                    subprocess.run(["chmod", "644", eeprom_path], stderr=subprocess.STDOUT)
+                    self.eeprom = self._read_bin_file(eeprom_path, 256)
+                except:
+                    return 'N/A'
+            return self.eeprom[21:32].decode()
+
+        return 'N/A'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the PSU
+
+        Returns:
+            bool: True if PSU is operating properly, False if not
+        """
+        result = read_sysfs_file(REG_DIR+f"psu{self.index}_pwr_ok")
+        if result == '1':
+            return True
+
+        return False
+
+    def get_voltage(self):
+        """
+        Retrieves current PSU voltage output
+
+        Returns:
+            A float number, the output voltage in volts,
+            e.g. 12.1
+        """
+        if self.get_presence():
+            v_out = read_sysfs_file(self.psu_dir+"psu_v_out")
+        else:
+            v_out = 0.0
+
+        return float(v_out)/1000
+
+    def get_current(self):
+        """
+        Retrieves present electric current supplied by PSU
+
+        Returns:
+            A float number, the electric current in amperes, e.g 15.4
+        """
+        if self.get_presence():
+            i_out = read_sysfs_file(self.psu_dir+"psu_i_out")
+        else:
+            i_out = 0.0
+
+        return float(i_out)/1000
+
+    def get_power(self):
+        """
+        Retrieves current energy supplied by PSU
+
+        Returns:
+            A float number, the power in watts, e.g. 302.6
+        """
+        if self.get_presence():
+            p_out = read_sysfs_file(self.psu_dir+"psu_p_out")
+        else:
+            p_out = 0.0
+
+        return float(p_out)/1000
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self.index
+
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+
+        Returns:
+            A float number, the high threshold output voltage in volts,
+            e.g. 12.1
+        """
+        return float(PSU_OUTPUT_VOLTAGE_MAX/1000)
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+
+        Returns:
+            A float number, the low threshold output voltage in volts,
+            e.g. 12.1
+        """
+        return float(PSU_OUTPUT_VOLTAGE_MIN/1000)
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True
+
+    def get_powergood_status(self):
+        """
+        Retrieves the powergood status of PSU
+        Returns:
+            A boolean, True if PSU has stablized its output voltages and
+            passed all its internal self-tests, False if not.
+        """
+        return self.get_status()
+
+    def get_status_led(self):
+        """
+        Gets the state of the PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        if self.get_presence():
+            if self.get_status():
+                return self.STATUS_LED_COLOR_GREEN
+            if self.get_power() == 0.0:
+                return self.STATUS_LED_COLOR_OFF
+            return self.STATUS_LED_COLOR_RED
+        return 'N/A'
+
+    def set_status_led(self, _color):
+        """
+        Sets the state of the PSU status LED
+        Args:
+            color: A string representing the color with which to set the
+                   PSU status LED
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        return False
+
+    def get_status_master_led(self):
+        """
+        Gets the state of the front panel PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        if self.get_presence():
+            if self.get_status():
+                return self.STATUS_LED_COLOR_GREEN
+            if self.get_power() == 0.0:
+                return self.STATUS_LED_COLOR_OFF
+            return self.STATUS_LED_COLOR_AMBER
+        return 'N/A'
+
+    def set_status_master_led(self, _color):
+        """
+        Sets the state of the front panel PSU status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        return False

--- a/ixr7220d4/sonic_platform/sfp.py
+++ b/ixr7220d4/sonic_platform/sfp.py
@@ -1,0 +1,218 @@
+"""
+     Name: sfp.py, version: 1.0
+
+     Description: Module contains the definitions of SFP related APIs
+     for Nokia IXR 7220 D4 platform.
+
+     Copyright (c) 2024, Nokia
+     All rights reserved.
+"""
+try:
+    import time
+    import sys
+    from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_py_common import logger, device_info
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+
+QSFP_PORT_NUM = 36
+QSFP_DD_START = 28
+QSFP_IN_CPLD3 = 18
+
+CPLD1_DIR = "/sys/bus/i2c/devices/10-0060/"
+CPLD3_DIR = "/sys/bus/i2c/devices/10-0064/"
+
+SYSLOG_IDENTIFIER = "sfp"
+sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+sonic_logger.set_min_log_priority_info()
+
+class Sfp(SfpOptoeBase):
+    """
+    Nokia IXR-7220 D4 Platform-specific Sfp refactor class
+    """
+    instances = []
+
+    def __init__(self, index, sfp_type, eeprom_path):
+        SfpOptoeBase.__init__(self)
+
+        self.index       = index
+        self.port_num    = index
+        self.sfp_type    = sfp_type
+        self.eeprom_path = eeprom_path
+        if index <= QSFP_DD_START:
+            self.name = sfp_type + '_' + str(index)
+            self.port_name = sfp_type + '_' + str(index-1)
+        else:
+            self.name = sfp_type + '_' + str(index-QSFP_DD_START)
+            self.port_name = sfp_type + '_' + str(index-QSFP_DD_START-1)
+
+        sonic_logger.log_info(f"Sfp __init__ index {index} setting name to {self.name} and eeprom_path to {self.eeprom_path}")
+
+        Sfp.instances.append(self)
+
+    def get_eeprom_path(self):
+        """
+        Retrieves the eeprom path
+        Returns:
+            string: eeprom path
+        """
+        return self.eeprom_path
+
+    def get_presence(self):
+        """
+        Retrieves the presence
+        Returns:
+            bool: True if is present, False if not
+        """
+        sfpstatus = read_sysfs_file(CPLD1_DIR + f"qsfp{self.index}_mod_prsnt")
+
+        return True if sfpstatus == '0' else False
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        return self.name
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        Returns:
+            integer: The 1-based relative physical position in parent device or
+                     -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+
+        return True
+
+    def _get_error_code(self):
+        """
+        Get error code of the SFP module
+
+        Returns:
+            The error code
+        """
+        return NotImplementedError
+
+    def get_error_description(self):
+        """
+        Get error description
+
+        Args:
+            error_code: The error code returned by _get_error_code
+
+        Returns:
+            The error description
+        """
+        if not self.get_presence():
+            error_description = self.SFP_STATUS_UNPLUGGED
+        else:
+            error_description = self.SFP_STATUS_OK
+
+        return error_description
+
+    def get_reset_status(self):
+        """
+        Retrieves the reset status of SFP
+        Returns:
+            A Boolean, True if reset enabled, False if disabled
+        """
+
+        result = read_sysfs_file(CPLD1_DIR+f"qsfp{self.index}_rstn")
+
+        return True if result == '0' else False
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        """
+        return not self.get_reset_status()
+
+    def reset(self):
+        """
+        Reset SFP.
+        Returns:
+            A boolean, True if successful, False if not
+        """
+        if not self.get_presence():
+            sys.stderr.write("Error: Port {self.index} not inserted, could not reset it.\n\n")
+            return False
+        sonic_logger.log_info(f"Reseting port #{self.index}.")
+
+        result1 = 'ERR'
+        result2 = 'ERR'
+        t = 0
+
+        if self.index <= QSFP_PORT_NUM:
+            result2 = write_sysfs_file(CPLD1_DIR + f"qsfp{self.index}_reset", '1')
+            time.sleep(0.5)
+            if self.index <= QSFP_DD_START:
+                result2 = write_sysfs_file(CPLD3_DIR + f"qsfp{self.index}_lpmod", '0')
+            else:
+                result2 = write_sysfs_file(CPLD3_DIR + f"qsfp{self.index}_lpmod", '1')
+            time.sleep(0.5)
+            result1 = write_sysfs_file(CPLD1_DIR + f"qsfp{self.index}_rstn", '0')
+            while t < 10:
+                if read_sysfs_file(CPLD1_DIR + f"qsfp{self.index}_reset") == '2':
+                    result1 = write_sysfs_file(CPLD1_DIR+f"qsfp{self.index}_rstn", '1')
+                    time.sleep(2)
+                    break
+                time.sleep(0.5)
+                if t == 8:
+                    sonic_logger.log_info(f"Reset port #{self.index} timeout, reset failed.")
+                    return False
+                t = t + 1
+
+            result2 = write_sysfs_file(CPLD1_DIR + f"qsfp{self.index}_reset", '3')
+        else:
+            return False
+
+        if result1 != 'ERR' and result2 != 'ERR':
+            return True
+
+        return False
+
+
+    def set_lpmode(self, lpmode):
+        """
+        Sets the lpmode (low power mode) of SFP
+        Args:
+            lpmode: A Boolean, True to enable lpmode, False to disable it
+            Note  :
+        Returns:
+            A boolean, True if lpmode is set successfully, False if not
+        """
+        result = 'ERR'
+
+        result = write_sysfs_file(CPLD3_DIR + f"qsfp{self.index}_lpmod", '1' if lpmode else '0')
+
+        if result != 'ERR':
+            return True
+
+        return False
+
+    def get_lpmode(self):
+        """
+        Retrieves the lpmode (low power mode) status of this SFP
+        Returns:
+            A Boolean, True if lpmode is enabled, False if disabled
+        """
+        result = 'ERR'
+
+        result = read_sysfs_file(CPLD3_DIR+f"qsfp{self.index}_lpmod")
+
+        if result == '1':
+            return True
+
+        return False

--- a/ixr7220d4/sonic_platform/sfp_event.py
+++ b/ixr7220d4/sonic_platform/sfp_event.py
@@ -1,0 +1,121 @@
+"""
+    listen for the SFP change event and return to chassis.
+"""
+try:
+    import time
+    from sonic_py_common import logger
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+# system level event/error
+EVENT_ON_ALL_SFP = '-1'
+SYSTEM_NOT_READY = 'system_not_ready'
+SYSTEM_READY = 'system_become_ready'
+SYSTEM_FAIL = 'system_fail'
+
+# SFP PORT numbers
+QSFP_PORT_NUM = 32
+PORT_START    = 1
+PORT_END      = 36
+
+CPLD1_DIR = "/sys/bus/i2c/devices/10-0060/"
+CPLD2_DIR = "/sys/bus/i2c/devices/10-0062/"
+CPLD3_DIR = "/sys/bus/i2c/devices/10-0064/"
+SYSLOG_IDENTIFIER = "sfp_event"
+sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+sonic_logger.set_min_log_priority_info()
+
+class SfpEvent:
+    ''' Listen to plugin/plugout cable events '''
+
+    def __init__(self):
+        self.handle = None
+        self.modprs_list = []
+
+    def initialize(self):
+        """
+        Initialize SFP
+        """
+        # Get Transceiver status
+        time.sleep(5)
+        self.modprs_list = self._get_transceiver_status()
+        sonic_logger.log_info(f"Initial SFP presence={str(self.modprs_list)}")
+
+    def _get_transceiver_status(self):
+        reg_value = []
+
+        for p in range(PORT_START, PORT_START + PORT_END):
+            sfp_prs = read_sysfs_file(CPLD1_DIR + f"qsfp{p}_mod_prsnt")
+            reg_value.append(sfp_prs)
+            if p < 19:
+                write_sysfs_file(CPLD3_DIR + f"qsfp{p}_prs", sfp_prs)
+            else:
+                write_sysfs_file(CPLD2_DIR + f"qsfp{p}_prs", sfp_prs)
+
+        port_status = [not bool(int(x)) for x in reg_value]
+        # True: present, False: absent
+        for port in range (PORT_START, PORT_START + PORT_END):
+            if not port_status[port-1]: # if absent skip ...
+                continue
+
+            reset_status = read_sysfs_file(CPLD1_DIR+f"qsfp{port}_reset")
+            if reset_status == '1':
+                sonic_logger.log_info(f"Port #{port} is reseting...")
+                port_status[port-1] = False
+                write_sysfs_file(CPLD1_DIR+f"qsfp{port}_reset", '2')
+            elif reset_status == '2':
+                sonic_logger.log_info(f"Port #{port} is still reseting... ")
+                port_status[port-1] = False
+            elif reset_status == '3':
+                sonic_logger.log_info(f"Port #%{port} reset done... ")
+                port_status[port-1] = True
+                write_sysfs_file(CPLD1_DIR+f"qsfp{port}_reset", '0')
+
+        return port_status
+
+    def check_sfp_status(self, port_change, timeout):
+        """
+        check_sfp_status called from get_change_event, this will return correct
+            status of all SFP ports if there is a change in any of them
+        """
+        start_time = time.time()
+        forever = False
+
+        if timeout == 0:
+            forever = True
+        elif timeout > 0:
+            timeout = timeout / float(1000)  # Convert to secs
+        else:
+            return False, {}
+        end_time = start_time + timeout
+
+        if start_time > end_time:
+            return False, {}  # Time wrap or possibly incorrect timeout
+
+        while timeout >= 0:
+            # Check for OIR events and return updated port_change
+            port_status = self._get_transceiver_status()
+            if port_status != self.modprs_list:
+                for i in range(PORT_END):
+                    if port_status[i] != self.modprs_list[i]:
+                        if port_status[i]:
+                            port_change[i+1] = '1' #ins
+                        else:
+                            port_change[i+1] = '0' #rem
+
+                # Update reg value
+                self.modprs_list = port_status
+                return True, port_change
+
+            if forever:
+                time.sleep(1)
+            else:
+                timeout = end_time - time.time()
+                if timeout >= 1:
+                    time.sleep(1)  # We poll at 1 second granularity
+                else:
+                    if timeout > 0:
+                        time.sleep(timeout)
+                    return True, {}
+        return False, {}

--- a/ixr7220d4/sonic_platform/sysfs.py
+++ b/ixr7220d4/sonic_platform/sysfs.py
@@ -1,0 +1,48 @@
+"""
+    Nokia IXR7220 sysfs functions
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the PSUs' information which are available in the platform
+"""
+
+def read_sysfs_file(sysfs_file):
+    """
+    On successful read, returns the value read from given
+    reg_name and on failure returns ERR
+    """
+    rv = 'ERR'
+
+    try:
+        with open(sysfs_file, 'r', encoding='utf-8') as fd:
+            rv = fd.read()
+            fd.close()
+    except FileNotFoundError:
+        print(f"Error: {sysfs_file} doesn't exist.")
+    except PermissionError:
+        print(f"Error: Permission denied when reading file {sysfs_file}.")
+    except IOError:
+        print(f"IOError: An error occurred while reading file {sysfs_file}.")
+    if rv != 'ERR':
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+    return rv
+
+def write_sysfs_file(sysfs_file, value):
+    """
+    On successful write, the value read will be written on
+    reg_name and on failure returns ERR
+    """
+    rv = 'ERR'
+
+    try:
+        with open(sysfs_file, 'w', encoding='utf-8') as fd:
+            rv = fd.write(value)
+            fd.close()
+    except FileNotFoundError:
+        print(f"Error: {sysfs_file} doesn't exist.")
+    except PermissionError:
+        print(f"Error: Permission denied when writing file {sysfs_file}.")
+    except IOError:
+        print(f"IOError: An error occurred while writing file {sysfs_file}.")
+
+    return rv

--- a/ixr7220d4/sonic_platform/test/README
+++ b/ixr7220d4/sonic_platform/test/README
@@ -1,0 +1,1 @@
+This directory contains unit tests of the Platform API 2.0

--- a/ixr7220d4/sonic_platform/test/test-chassis.py
+++ b/ixr7220d4/sonic_platform/test/test-chassis.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+try:
+    import sonic_platform.platform
+    import sonic_platform.chassis
+    import unittest
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+
+class Test1(unittest.TestCase):
+    def test_1(self):
+        print("-----------------")
+        print("Chassis Unit Test")
+        print("-----------------")
+
+        chassis = sonic_platform.platform.Platform().get_chassis()
+        print("  Chassis name: {}".format(chassis.get_name()))
+
+        print("  Chassis presence: {}".format(chassis.get_presence()))
+
+        print("  Chassis model: {}".format(chassis.get_model()))
+
+        print("  Chassis serial: {}".format(chassis.get_serial()))
+
+        print("  Chassis revision: {}".format(chassis.get_revision()))
+
+        print("  Chassis status: {}".format(chassis.get_status()))
+
+        print("  Chassis base_mac: {}".format(chassis.get_base_mac()))
+
+        print("  Chassis reboot cause: {}\n".format(chassis.get_reboot_cause()))
+
+        print("  Chassis watchdog: {}".format(chassis.get_watchdog()))
+
+        print("  Chassis num_components: {}".format(chassis.get_num_components()))
+
+        print("  Chassis all_components: {}\n".format(chassis.get_all_components()))
+
+        print("  Chassis num_modules: {}".format(chassis.get_num_modules()))
+
+        print("  Chassis all_modules: {}\n".format(chassis.get_all_modules()))
+
+        print("  Chassis num_fans: {}".format(chassis.get_num_fans()))
+
+        print("  Chassis all_fans: {}\n".format(chassis.get_all_fans()))
+
+        print("  Chassis num_psus: {}".format(chassis.get_num_psus()))
+
+        print("  Chassis all_psus: {}\n".format(chassis.get_all_psus()))
+
+        print("  Chassis num_thermals: {}".format(chassis.get_num_thermals()))
+
+        print("  Chassis all_thermals: {}\n".format(chassis.get_all_thermals()))
+
+        print("  Chassis num_sfps: {}".format(chassis.get_num_sfps()))
+
+        print("  Chassis all_sfps: {}\n".format(chassis.get_all_sfps()))
+
+        print("  Chassis eeprom: {}".format(chassis.get_eeprom()))
+
+        print("  Chassis system_eeprom_info: {}\n".format(chassis.get_system_eeprom_info()))
+
+        colors = ['off', 'green', 'amber', 'green_blink', 'blue']
+
+        for col in colors:
+            chassis.set_status_led(col)
+            tcol = chassis.get_status_led()
+            self.assertEqual(col, tcol)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ixr7220d4/sonic_platform/test/test-component.py
+++ b/ixr7220d4/sonic_platform/test/test-component.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------------")
+    print("Chassis Component Unit Test")
+    print("---------------------------")
+
+    chassis = Chassis()
+
+    for component in chassis.get_all_components():
+        print("    Name: {}".format(component.get_name()))
+        print("        Description: {}".format(component.get_description()))
+        print("        FW version: {}\n".format(component.get_firmware_version()))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220d4/sonic_platform/test/test-eeprom.py
+++ b/ixr7220d4/sonic_platform/test/test-eeprom.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("------------------------")
+    print("Chassis eeprom Unit Test")
+    print("------------------------")
+
+    chassis = Chassis()
+
+    eeprom = chassis.get_eeprom()
+
+    print("    Model: {}, Service Tag: {}".format(eeprom.modelstr(),
+                                             eeprom. service_tag_str()))
+    print("    Part#: {}, Serial#: {}".format(eeprom.part_number_str(),
+                                              eeprom.serial_number_str()))
+    print("    Base MAC: {}".format(eeprom.base_mac_addr()))
+
+
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220d4/sonic_platform/test/test-fan-drawer.py
+++ b/ixr7220d4/sonic_platform/test/test-fan-drawer.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+import unittest
+from sonic_platform.chassis import Chassis
+
+class Test1(unittest.TestCase):
+    def test_1(self):
+        print("---------------------------")
+        print("Chassis Fan Drawer Unit Test")
+        print("---------------------------")
+
+        chassis = Chassis()
+
+        for fan_drawer in chassis.get_all_fan_drawers():
+            if not fan_drawer.get_presence():
+                print("    Name: {} not present".format(fan_drawer.get_name()))
+            else:
+                print("    Name:", fan_drawer.get_name())
+                print("        Presence: {}, Status: {}, LED: {}".format(fan_drawer.get_presence(),
+                                                                        fan_drawer.get_status(),
+                                                                        fan_drawer.get_status_led()))
+                print("        Model: {}, Serial#: {}".format(fan_drawer.get_model(),
+                                                            fan_drawer.get_serial()))
+                print("        Part#: {}".format(fan_drawer.get_part_number()))
+                print("        Direction: {}\n".format(fan_drawer.get_direction()))
+                print("        Replaceable: {}, Index: {}\n".format(fan_drawer.is_replaceable(), fan_drawer.get_position_in_parent()))
+
+
+            for color in ['off', 'red', 'green']:
+                fan_drawer.set_status_led(color)
+                t_value = fan_drawer.get_status_led()
+                self.assertEqual(color, t_value)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ixr7220d4/sonic_platform/test/test-fan.py
+++ b/ixr7220d4/sonic_platform/test/test-fan.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------")
+    print("Chassis Fan Unit Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    for fan in chassis.get_all_fans():
+        if not fan.get_presence():
+            print("    Name: {} not present".format(fan.get_name()))
+        else:
+            print("    Name:", fan.get_name())
+            print("        Presence: {}, Status: {}, LED: {}".format(fan.get_presence(),
+                                                                     fan.get_status(),
+                                                                     fan.get_status_led()))
+            print("        Model: {}, Serial#: {}".format(fan.get_model(),
+                                                          fan.get_serial()))
+            print("        Part#: {}, Service Tag: {}".format(fan.get_part_number(),
+                                                              fan.get_service_tag()))
+            fan.set_speed(80)
+            print("        Direction: {}, Speed: {}%, Target Speed: {}%\n".format(fan.get_direction(),
+                                                                                    str(fan.get_speed()),
+                                                                                    str(fan.get_target_speed())))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220d4/sonic_platform/test/test-psu.py
+++ b/ixr7220d4/sonic_platform/test/test-psu.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------")
+    print("Chassis PSU Unit Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    for psu in chassis.get_all_psus():
+        if not psu.get_presence():
+            print("    Name: {} not present".format(psu.get_name()))
+        else:
+            print("    Name:", psu.get_name())
+            print("    Active num:", psu._get_active_psus())
+            print("    Master LED:", psu.get_status_master_led())
+
+            print("        Presence: {}, Status: {}, LED: {}".format(psu.get_presence(),
+                                                                     psu.get_status(),
+                                                                     psu.get_status_led()))
+            print("        Model: {}, Serial#: {}, Part#: {}".format(psu.get_model(),
+                                                                     psu.get_serial(),
+                                                                     psu.get_part_number()))
+            try:
+                current = psu.get_current()
+            except NotImplementedError:
+                current = "NA"
+            try:
+                power = psu.get_power()
+            except NotImplementedError:
+                power = "NA"
+
+            print("        Voltage: {}, Current: {}, Power: {}\n".format(psu.get_voltage(),
+                                                                         current,
+                                                                         power))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220d4/sonic_platform/test/test-sfp.py
+++ b/ixr7220d4/sonic_platform/test/test-sfp.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform.chassis import Chassis
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+def main():
+    print("---------------------")
+    print("Chassis SFP Unit Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    PORT_START = 1
+    PORT_END = 34
+
+    for physical_port in range(PORT_START, PORT_END):
+        print(" ")
+        print(" SFP transceiver tests  PORT = ", physical_port)
+        name = chassis.get_sfp(physical_port).get_name()
+        print(" SFP transceiver tests  NAME = ", name)
+
+        presence = chassis.get_sfp(physical_port).get_presence()
+        print("TEST 1 - sfp presence       [ True ] ", physical_port, presence)
+
+        status = chassis.get_sfp(physical_port).get_reset_status()
+        print("TEST 2 - sfp reset status   [ False ] ", physical_port, status)
+
+        txdisable = chassis.get_sfp(physical_port).get_tx_disable()
+        print("TEST 3 - sfp tx_disable     [ False ] ", physical_port, txdisable)
+
+        rxlos = chassis.get_sfp(physical_port).get_rx_los()
+        print("TEST 4 - sfp status rxlos   [ False ] ", physical_port, rxlos)
+
+        txfault = chassis.get_sfp(physical_port).get_tx_fault()
+        print("TEST 5 - sfp status txfault [ False ] ", physical_port, txfault)
+
+        lpmode = chassis.get_sfp(physical_port).get_lpmode()
+        print("TEST 6 - sfp enable lpmode  [ False ] ", physical_port, lpmode)
+
+        trans_info = chassis.get_sfp(physical_port).get_transceiver_info()
+        print("TEST 7 - sfp transceiver info for port:", physical_port, trans_info)
+
+        trans_status = chassis.get_sfp(physical_port).get_transceiver_bulk_status()
+        print("TEST 8 - sfp bulk status for port:", physical_port, trans_status)
+
+        threshold = chassis.get_sfp(physical_port).get_transceiver_threshold_info()
+        print("TEST 9 - sfp bulk status for port:", physical_port, threshold)
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220d4/sonic_platform/test/test-thermal.py
+++ b/ixr7220d4/sonic_platform/test/test-thermal.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+def main():
+    print("-------------------------")
+    print("Chassis Thermal Unit Test")
+    print("-------------------------")
+
+    chassis = Chassis()
+
+    for thermal in chassis.get_all_thermals():
+        if not thermal.get_presence():
+            print("    Name: {} not present".format(thermal.get_name()))
+        else:
+            print("    Name:", thermal.get_name())
+            print("        Presence: {}, Status: {}".format(thermal.get_presence(),
+                                                            thermal.get_status()))
+            print("        Model: {}, Serial#: {}".format(thermal.get_model(),
+                                                          thermal.get_serial()))
+            print("        Temperature(C): {}".format(thermal.get_temperature()))
+
+            try:
+                low_thresh = thermal.get_low_threshold()
+            except NotImplementedError:
+                low_thresh = "NA"
+            try:
+                high_thresh = thermal.get_high_threshold()
+            except NotImplementedError:
+                high_thresh = "NA"
+
+            print("        Low Threshold(C): {}, High Threshold(C): {}".format(low_thresh,
+                                                                               high_thresh))
+
+            try:
+                crit_low_thresh = thermal.get_low_critical_threshold()
+            except NotImplementedError:
+                crit_low_thresh = "NA"
+            try:
+                crit_high_thresh = thermal.get_high_critical_threshold()
+            except NotImplementedError:
+                crit_high_thresh = "NA"
+
+            print("        Crit Low Threshold(C): {}, Crit High Threshold(C): {}\n".format(crit_low_thresh,
+                                                                                           crit_high_thresh))
+
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220d4/sonic_platform/test/test-watchdog.py
+++ b/ixr7220d4/sonic_platform/test/test-watchdog.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+from sonic_platform.chassis import Chassis
+
+
+def main():
+    print("---------------------")
+    print("Chassis Watchdog Test")
+    print("---------------------")
+
+    chassis = Chassis()
+
+    watchdog = chassis.get_watchdog()
+
+    print("    Armed: {}".format(watchdog.is_armed()))
+    print("    Time Left: {}".format(watchdog.get_remaining_time()))
+
+if __name__ == '__main__':
+    main()

--- a/ixr7220d4/sonic_platform/thermal.py
+++ b/ixr7220d4/sonic_platform/thermal.py
@@ -1,0 +1,233 @@
+"""
+    Nokia IXR7220-D4-36D
+
+    Module contains an implementation of SONiC Platform Base API and
+    provides the Thermals' information which are available in the platform
+"""
+
+try:
+    import os
+    import glob
+    from sonic_platform_base.thermal_base import ThermalBase
+    from sonic_py_common import logger
+    from swsscommon.swsscommon import SonicV2Connector
+    from sonic_platform.sysfs import read_sysfs_file
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+sonic_logger = logger.Logger('thermal')
+
+class Thermal(ThermalBase):
+    """Nokia platform-specific Thermal class"""
+
+    HWMON_DIR = "/sys/bus/i2c/devices/{}/hwmon/hwmon*/"
+    THRESHOLD = [60.0, 60.0, 60.0, 60.0, 60.0, 100.0, 90.0]
+    CRITICAL_THRESHOLD = [70.0, 70.0, 70.0, 70.0, 70.0, 104.0, 100.0]
+    I2C_DEV_LIST = ["15-0048", "15-0049", "15-004a", "15-004c", "15-004b"]
+    THERMAL_NAME = ["MB Front", "MB Rear", "MB Left",
+                    "MB Right", "CPU Board", "CPU", "ASIC TD4"]
+
+    def __init__(self, thermal_index):
+        ThermalBase.__init__(self)
+        self.index = thermal_index + 1
+        self.dependency = None
+        self._minimum = None
+        self._maximum = None
+        self.thermal_high_crit_thresh_file = None
+        self.thermal_high_thres = None
+        self.__create_i2c_tree()
+
+    def __create_i2c_tree(self):
+
+        # special cases
+        if self.index == len(self.THERMAL_NAME):     # MAC internal sensor
+            return
+        elif self.index == len(self.THERMAL_NAME)-1: # CPU internal sensor
+            self.device_path = glob.glob("/sys/bus/platform/devices/coretemp.0/hwmon/hwmon*/")
+            self.thermal_tmp_file = self.device_path[0] + "temp1_input"
+        else:
+            if not os.path.exists(f"/sys/bus/i2c/devices/{self.I2C_DEV_LIST[self.index-1]}"):
+                i2c_addr = "0x" + self.I2C_DEV_LIST[self.index-1][-2:]
+                os.system(f"echo lm75 {i2c_addr} > /sys/bus/i2c/devices/i2c-15/new_device")
+
+            self.device_path = glob.glob(self.HWMON_DIR.format(self.I2C_DEV_LIST[self.index-1]))
+            self.thermal_tmp_file = self.device_path[0] + "temp1_input"
+
+    def get_name(self):
+        """
+        Retrieves the name of the thermal
+
+        Returns:
+            string: The name of the thermal
+        """
+        return self.THERMAL_NAME[self.index - 1]
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the thermal
+
+        Returns:
+            bool: True if thermal is present, False if not
+        """
+        if self.dependency:
+            return self.dependency.get_presence()
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the Thermal
+
+        Returns:
+            string: Model/part number of Thermal
+        """
+        return 'NA'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the Thermal
+
+        Returns:
+            string: Serial number of Thermal
+        """
+        return 'NA'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the thermal
+
+        Returns:
+            A boolean value, True if thermal is operating properly,
+            False if not
+        """
+        if self.dependency:
+            return self.dependency.get_status()
+        return True
+
+    def get_temperature(self):
+        """
+        Retrieves current temperature reading from thermal
+
+        Returns:
+            A float number of current temperature in Celsius up to
+            nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.index == len(self.THERMAL_NAME):
+            db = SonicV2Connector()
+            db.connect(db.STATE_DB)
+            data_dict = db.get_all(db.STATE_DB, 'ASIC_TEMPERATURE_INFO')
+            thermal_tmp = float(data_dict['maximum_temperature'])
+        else:
+            thermal_tmp = read_sysfs_file(self.thermal_tmp_file)
+            if (thermal_tmp != 'ERR'):
+                thermal_tmp = float(thermal_tmp) / 1000
+            else:
+                thermal_tmp = 0
+
+        if self._minimum is None or self._minimum > thermal_tmp:
+            self._minimum = thermal_tmp
+        if self._maximum is None or self._maximum < thermal_tmp:
+            self._maximum = thermal_tmp
+
+        return float(f"{thermal_tmp:.3f}")
+
+    def get_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of thermal
+
+        Returns:
+            A float number, the high threshold temperature of thermal in
+            Celsius up to nearest thousandth of one degree Celsius,
+            e.g. 30.125
+        """
+        return self.THRESHOLD[self.index - 1]
+
+    def set_high_threshold(self, temperature):
+        """
+        Sets the high threshold temperature of thermal
+
+        Args :
+            temperature: A float number up to nearest thousandth of one
+            degree Celsius, e.g. 30.125
+        Returns:
+            A boolean, True if threshold is set successfully, False if
+            not
+        """
+        # Thermal threshold values are pre-defined based on HW.
+        return False
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature of thermal
+
+        Returns:
+            A float number, the high critical threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        return self.CRITICAL_THRESHOLD[self.index - 1]
+
+    def set_high_critical_threshold(self):
+        """
+        Sets the high_critical threshold temperature of thermal
+
+        Args :
+            temperature: A float number up to nearest thousandth of one
+            degree Celsius, e.g. 30.125
+        Returns:
+            A boolean, True if threshold is set successfully, False if
+            not
+        """
+        # Thermal threshold values are pre-defined based on HW.
+        return False
+
+    def get_low_threshold(self):
+        """
+        Retrieves the low threshold temperature of thermal
+        Returns:
+            A float number, the low threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        return 0.0
+
+    def set_low_threshold(self, temperature):
+        """
+        Sets the low threshold temperature of thermal
+
+        Args :
+            temperature: A float number up to nearest thousandth of one
+            degree Celsius, e.g. 30.125
+        Returns:
+            A boolean, True if threshold is set successfully, False if
+            not
+        """
+        # Thermal threshold values are pre-defined based on HW.
+        return False
+
+    def get_minimum_recorded(self):
+        """
+        Retrieves minimum recorded temperature
+        """
+        self.get_temperature()
+        return self._minimum
+
+    def get_maximum_recorded(self):
+        """
+        Retrieves maxmum recorded temperature
+        """
+        self.get_temperature()
+        return self._maximum
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device
+        Returns:
+            integer: The 1-based relative physical position in parent device
+        """
+        return self.index
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False

--- a/ixr7220d4/sonic_platform/thermal_actions.py
+++ b/ixr7220d4/sonic_platform/thermal_actions.py
@@ -1,0 +1,285 @@
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_action_base import ThermalPolicyActionBase
+    from sonic_platform_base.sonic_thermal_control.thermal_json_object import thermal_json_object
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+sonic_logger = logger.Logger('thermal_actions')
+
+
+class SetFanSpeedAction(ThermalPolicyActionBase):
+    """
+    Base thermal action class to set speed for fans
+    """
+    # JSON field definition
+    JSON_FIELD_SPEED = 'speed'
+    JSON_FIELD_DEFAULT_SPEED = 'default_speed'
+    JSON_FIELD_THRESHOLD1_SPEED = 'threshold1_speed'
+    JSON_FIELD_THRESHOLD2_SPEED = 'threshold2_speed'
+    JSON_FIELD_HIGHTEMP_SPEED = 'hightemp_speed'
+
+    def __init__(self):
+        """
+        Constructor of SetFanSpeedAction
+        """
+        self.default_speed    = 41
+        self.threshold1_speed = 46
+        self.threshold2_speed = 69
+        self.hightemp_speed   = 100
+        self.speed = self.default_speed
+
+    def load_from_json(self, json_obj):
+        """
+        Construct SetFanSpeedAction via JSON. JSON example:
+            {
+                "type": "fan.all.set_speed"
+                "speed": "100"
+            }
+        :param json_obj: A JSON object representing a SetFanSpeedAction action.
+        :return:
+        """
+        if SetFanSpeedAction.JSON_FIELD_SPEED in json_obj:
+            speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_SPEED])
+            if speed < 0 or speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid speed value {speed} in JSON policy file, valid value should be [0, 100]')
+            self.speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_SPEED} in JSON policy file')
+
+    @classmethod
+    def set_all_fan_speed(cls, thermal_info_dict, speed):
+        from .thermal_infos import FanInfo
+        if FanInfo.INFO_NAME in thermal_info_dict and isinstance(thermal_info_dict[FanInfo.INFO_NAME], FanInfo):
+            fan_info_obj = thermal_info_dict[FanInfo.INFO_NAME]
+            for fan in fan_info_obj.get_presence_fans():
+                fan.set_speed(int(speed))
+
+
+@thermal_json_object('fan.all.set_speed')
+class SetAllFanSpeedAction(SetFanSpeedAction):
+    """
+    Action to set speed for all fans
+    """
+    def execute(self, thermal_info_dict):
+        """
+        Set speed for all fans
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        SetAllFanSpeedAction.set_all_fan_speed(thermal_info_dict, self.speed)
+
+
+@thermal_json_object('thermal.temp_check_and_set_all_b2f_fan_speed')
+class ThermalRecoverAction(SetFanSpeedAction):
+    """
+    Action to check thermal sensor temperature change status and set speed for all fans
+    """
+
+    def load_from_json(self, json_obj):
+        """
+        Construct ThermalRecoverAction via JSON. JSON example:
+            {
+                "type": "thermal.temp_check_and_set_all_fan_speed"
+                "default_speed": "25",
+                "threshold1_speed": "40",
+                "threshold2_speed": "75",
+                "hightemp_speed": "100"
+            }
+        :param json_obj: A JSON object representing a ThermalRecoverAction action.
+        :return:
+        """
+        if SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED in json_obj:
+            default_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED])
+            if default_speed < 0 or default_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid default speed value {default_speed} in JSON policy file, valid value should be [0, 100]')
+            self.default_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED} in JSON policy file')
+
+        if SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED in json_obj:
+            threshold1_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED])
+            if threshold1_speed < 0 or threshold1_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid default speed value {threshold1_speed} in JSON policy file, valid value should be [0, 100]')
+            self.threshold1_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED} in JSON policy file')
+
+        if SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED in json_obj:
+            threshold2_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED])
+            if threshold2_speed < 0 or threshold2_speed > 100:
+                raise ValueError('SetFanSpeedAction invalid default speed value {} in JSON policy file, valid value should be [0, 100]'.
+                                 format(threshold2_speed))
+            self.threshold2_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED])
+        else:
+            raise ValueError('SetFanSpeedAction missing mandatory field {} in JSON policy file'.
+                             format(SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED))
+
+        if SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED in json_obj:
+            hightemp_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED])
+            if hightemp_speed < 0 or hightemp_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid hightemp speed value {hightemp_speed} in JSON policy file, valid value should be [0, 100]')
+            self.hightemp_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED} in JSON policy file')
+
+        sonic_logger.log_warning(f"ThermalRecoverAction: default: {self.default_speed}, threshold1: {self.threshold1_speed}, threshold2: {self.threshold2_speed}, hightemp: {self.hightemp_speed}")
+
+    def execute(self, thermal_info_dict):
+        """
+        Check check thermal sensor temperature change status and set speed for all fans
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        from .thermal_infos import ThermalInfo
+        if ThermalInfo.INFO_NAME in thermal_info_dict and \
+           isinstance(thermal_info_dict[ThermalInfo.INFO_NAME], ThermalInfo):
+
+            thermal_info_obj = thermal_info_dict[ThermalInfo.INFO_NAME]
+            if thermal_info_obj.is_set_fan_high_temp_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.hightemp_speed)
+            elif thermal_info_obj.is_set_fan_threshold_two_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.threshold2_speed)
+            elif thermal_info_obj.is_set_fan_threshold_one_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.threshold1_speed)
+            elif thermal_info_obj.is_set_fan_default_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.default_speed)
+
+@thermal_json_object('thermal.temp_check_and_set_all_f2b_fan_speed')
+class ThermalRecoverAction(SetFanSpeedAction):
+    """
+    Action to check thermal sensor temperature change status and set speed for all fans
+    """
+
+    def load_from_json(self, json_obj):
+        """
+        Construct ThermalRecoverAction via JSON. JSON example:
+            {
+                "type": "thermal.temp_check_and_set_all_fan_speed"
+                "default_speed": "25",
+                "threshold1_speed": "40",
+                "threshold2_speed": "75",
+                "hightemp_speed": "100"
+            }
+        :param json_obj: A JSON object representing a ThermalRecoverAction action.
+        :return:
+        """
+        if SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED in json_obj:
+            default_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED])
+            if default_speed < 0 or default_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid default speed value {default_speed} in JSON policy file, valid value should be [0, 100]')
+            self.default_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_DEFAULT_SPEED} in JSON policy file')
+
+        if SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED in json_obj:
+            threshold1_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED])
+            if threshold1_speed < 0 or threshold1_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid default speed value {threshold1_speed} in JSON policy file, valid value should be [0, 100]')
+            self.threshold1_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_THRESHOLD1_SPEED} in JSON policy file')
+
+        if SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED in json_obj:
+            threshold2_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED])
+            if threshold2_speed < 0 or threshold2_speed > 100:
+                raise ValueError('SetFanSpeedAction invalid default speed value {} in JSON policy file, valid value should be [0, 100]'.
+                                 format(threshold2_speed))
+            self.threshold2_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED])
+        else:
+            raise ValueError('SetFanSpeedAction missing mandatory field {} in JSON policy file'.
+                             format(SetFanSpeedAction.JSON_FIELD_THRESHOLD2_SPEED))
+
+        if SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED in json_obj:
+            hightemp_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED])
+            if hightemp_speed < 0 or hightemp_speed > 100:
+                raise ValueError(f'SetFanSpeedAction invalid hightemp speed value {hightemp_speed} in JSON policy file, valid value should be [0, 100]')
+            self.hightemp_speed = float(json_obj[SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED])
+        else:
+            raise ValueError(f'SetFanSpeedAction missing mandatory field {SetFanSpeedAction.JSON_FIELD_HIGHTEMP_SPEED} in JSON policy file')
+
+        sonic_logger.log_warning(f"ThermalRecoverAction: default: {self.default_speed}, threshold1: {self.threshold1_speed}, threshold2: {self.threshold2_speed}, hightemp: {self.hightemp_speed}")
+
+    def execute(self, thermal_info_dict):
+        """
+        Check check thermal sensor temperature change status and set speed for all fans
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        from .thermal_infos import ThermalInfo
+        if ThermalInfo.INFO_NAME in thermal_info_dict and \
+           isinstance(thermal_info_dict[ThermalInfo.INFO_NAME], ThermalInfo):
+
+            thermal_info_obj = thermal_info_dict[ThermalInfo.INFO_NAME]
+            if thermal_info_obj.is_set_fan_high_temp_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.hightemp_speed)
+            elif thermal_info_obj.is_set_fan_threshold_two_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.threshold2_speed)
+            elif thermal_info_obj.is_set_fan_threshold_one_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.threshold1_speed)
+            elif thermal_info_obj.is_set_fan_default_speed():
+                ThermalRecoverAction.set_all_fan_speed(thermal_info_dict, self.default_speed)
+
+@thermal_json_object('switch.shutdown')
+class SwitchPolicyAction(ThermalPolicyActionBase):
+    """
+    Base class for thermal action. Once all thermal conditions in a thermal policy are matched,
+    all predefined thermal action will be executed.
+    """
+    def execute(self, thermal_info_dict):
+        """
+        Take action when thermal condition matches. For example, adjust speed of fan or shut
+        down the switch.
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        sonic_logger.log_warning("Alarm for temperature critical is detected, reboot Device")
+
+@thermal_json_object('thermal_control.control')
+class ControlThermalAlgoAction(ThermalPolicyActionBase):
+    """
+    Action to control the thermal control algorithm
+    """
+    # JSON field definition
+    JSON_FIELD_STATUS = 'status'
+
+    def __init__(self):
+        self.status = True
+
+    def load_from_json(self, json_obj):
+        """
+        Construct ControlThermalAlgoAction via JSON. JSON example:
+            {
+                "type": "thermal_control.control"
+                "status": "true"
+            }
+        :param json_obj: A JSON object representing a ControlThermalAlgoAction action.
+        :return:
+        """
+        if ControlThermalAlgoAction.JSON_FIELD_STATUS in json_obj:
+            status_str = json_obj[ControlThermalAlgoAction.JSON_FIELD_STATUS].lower()
+            if status_str == 'true':
+                self.status = True
+            elif status_str == 'false':
+                self.status = False
+            else:
+                raise ValueError(f'Invalid {ControlThermalAlgoAction.JSON_FIELD_STATUS} field value, please specify true of false')
+        else:
+            raise ValueError('ControlThermalAlgoAction '
+                             f'missing mandatory field {ControlThermalAlgoAction.JSON_FIELD_STATUS} in JSON policy file')
+
+    def execute(self, thermal_info_dict):
+        """
+        Disable thermal control algorithm
+        :param thermal_info_dict: A dictionary stores all thermal information.
+        :return:
+        """
+        from .thermal_infos import ChassisInfo
+        if ChassisInfo.INFO_NAME in thermal_info_dict:
+            chassis_info_obj = thermal_info_dict[ChassisInfo.INFO_NAME]
+            chassis = chassis_info_obj.get_chassis()
+            thermal_manager = chassis.get_thermal_manager()
+            if self.status:
+                thermal_manager.start_thermal_control_algorithm()
+            else:
+                thermal_manager.stop_thermal_control_algorithm()

--- a/ixr7220d4/sonic_platform/thermal_conditions.py
+++ b/ixr7220d4/sonic_platform/thermal_conditions.py
@@ -1,0 +1,56 @@
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_condition_base import ThermalPolicyConditionBase
+    from sonic_platform_base.sonic_thermal_control.thermal_json_object import thermal_json_object
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+class FanCondition(ThermalPolicyConditionBase):
+    def get_fan_info(self, thermal_info_dict):
+        from .thermal_infos import FanInfo
+        if FanInfo.INFO_NAME in thermal_info_dict and isinstance(thermal_info_dict[FanInfo.INFO_NAME], FanInfo):
+            return thermal_info_dict[FanInfo.INFO_NAME]
+        return None
+
+
+@thermal_json_object('fan.any.absence')
+class AnyFanAbsenceCondition(FanCondition):
+    def is_match(self, thermal_info_dict):
+        fan_info_obj = self.get_fan_info(thermal_info_dict)
+        return len(fan_info_obj.get_absence_fans()) > 0 if fan_info_obj else False
+
+
+@thermal_json_object('fan.f2b.all.presence')
+class AllFanPresenceCondition(FanCondition):
+    def is_match(self, thermal_info_dict):
+        fan_info_obj = self.get_fan_info(thermal_info_dict)
+        if fan_info_obj and fan_info_obj.get_fan_type() == "intake":
+            return len(fan_info_obj.get_absence_fans()) == 0
+        else:
+            return False
+
+@thermal_json_object('fan.b2f.all.presence')
+class AllFanPresenceCondition(FanCondition):
+    def is_match(self, thermal_info_dict):
+        fan_info_obj = self.get_fan_info(thermal_info_dict)
+        if fan_info_obj and fan_info_obj.get_fan_type() == "exhaust":
+            return len(fan_info_obj.get_absence_fans()) == 0
+        else:
+            return False
+
+
+class ThermalCondition(ThermalPolicyConditionBase):
+    def get_thermal_info(self, thermal_info_dict):
+        from .thermal_infos import ThermalInfo
+        if ThermalInfo.INFO_NAME in thermal_info_dict and isinstance(thermal_info_dict[ThermalInfo.INFO_NAME], ThermalInfo):
+            return thermal_info_dict[ThermalInfo.INFO_NAME]
+        return None
+
+
+@thermal_json_object('thermal.over.high_critical_threshold')
+class ThermalOverHighCriticalCondition(ThermalCondition):
+    def is_match(self, thermal_info_dict):
+        thermal_info_obj = self.get_thermal_info(thermal_info_dict)
+        if thermal_info_obj:
+            return thermal_info_obj.is_over_high_critical_threshold()
+        return False
+

--- a/ixr7220d4/sonic_platform/thermal_infos.py
+++ b/ixr7220d4/sonic_platform/thermal_infos.py
@@ -1,0 +1,287 @@
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_info_base import ThermalPolicyInfoBase
+    from sonic_platform_base.sonic_thermal_control.thermal_json_object import thermal_json_object
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+logger = Logger()
+
+@thermal_json_object('fan_info')
+class FanInfo(ThermalPolicyInfoBase):
+    """
+    Fan information needed by thermal policy
+    """
+
+    # Fan information name
+    INFO_NAME = 'fan_info'
+
+    def __init__(self):
+        self._absence_fans = set()
+        self._presence_fans = set()
+        self._status_changed = False
+        self._fan_type = " "
+
+    def collect(self, chassis):
+        """
+        Collect absence and presence fans.
+        :param chassis: The chassis object
+        :return:
+        """
+        self._status_changed = False
+        for fan in chassis.get_all_fans():
+            if fan.get_presence() and fan not in self._presence_fans:
+                self._presence_fans.add(fan)
+                self._status_changed = True
+                if fan in self._absence_fans:
+                    self._absence_fans.remove(fan)
+            elif not fan.get_presence() and fan not in self._absence_fans:
+                self._absence_fans.add(fan)
+                self._status_changed = True
+                if fan in self._presence_fans:
+                    self._presence_fans.remove(fan)
+
+        self._fan_type = chassis.get_chassis_fan_type()
+
+    def get_absence_fans(self):
+        """
+        Retrieves absence fans
+        :return: A set of absence fans
+        """
+        return self._absence_fans
+
+    def get_presence_fans(self):
+        """
+        Retrieves presence fans
+        :return: A set of presence fans
+        """
+        return self._presence_fans
+
+    def is_status_changed(self):
+        """
+        Retrieves if the status of fan information changed
+        :return: True if status changed else False
+        """
+        return self._status_changed
+
+    def get_fan_type(self):
+        """
+        Retrieves the fan type (B2F, F2B) that currently is loaded into the chassis.
+        All fans should be either B2F or F2B.
+
+        Returns:
+            Airflow direction: FAN_DIRECTION_INTAKE for F2B,
+                               FAN_DIRECTION_EXHAUST for B2F,
+                               o/w " ".
+        """
+        return self._fan_type
+
+@thermal_json_object('thermal_info')
+class ThermalInfo(ThermalPolicyInfoBase):
+    """
+    Thermal information needed by thermal policy
+    """
+
+    # Fan information name
+    INFO_NAME = 'thermal_info'
+
+    def __init__(self):
+        self._old_threshold_level = -1
+        self._current_threshold_level = 0
+        self._num_fan_levels = 3
+
+    def collect(self, chassis):
+        """
+        Collect thermal sensor temperature change status
+        :param chassis: The chassis object
+        :return:
+        """
+        self._temps = []
+        self._over_high_critical_threshold = False
+        self._set_fan_default_speed = False
+        self._set_fan_threshold_one_speed = False
+        self._set_fan_threshold_two_speed = False
+        self._set_fan_high_temp_speed = False
+        self.__set_level_up_down_thresholds(chassis)
+
+        # Calculate average temp within the device
+        num_of_thermals = chassis.get_num_thermals()
+        for thermal_id in range(num_of_thermals):
+            self._temps.insert(thermal_id, chassis.get_thermal(thermal_id).get_temperature())
+
+
+       # Find current required threshold level
+        max_level = 0
+        min_level = [self._num_fan_levels for i in range(num_of_thermals)]
+
+        for thermal_id in range(num_of_thermals):
+            for level in range(self._num_fan_levels):
+
+                if self._temps[thermal_id]>self._level_up_threshold[level][thermal_id]:
+                    if max_level<level+1:
+                        max_level=level+1
+                if self._temps[thermal_id]<self._level_down_threshold[level][thermal_id]:
+                    if min_level[thermal_id]>level:
+                        min_level[thermal_id]=level
+
+        max_of_min_level=max(min_level)
+
+        #compare with running threshold level
+        if max_of_min_level > self._old_threshold_level:
+            max_of_min_level=self._old_threshold_level
+
+        self._current_threshold_level = max(max_of_min_level,max_level)
+
+        #set fan to max speed if one fan is down
+        for fan in chassis.get_all_fans():
+            if not fan.get_status():
+                self._current_threshold_level = 3
+
+       # Decide fan speed based on threshold level
+
+        if self._current_threshold_level != self._old_threshold_level:
+            if self._current_threshold_level == 0:
+                self._set_fan_default_speed = True
+            elif self._current_threshold_level == 1:
+                self._set_fan_threshold_one_speed = True
+            elif self._current_threshold_level == 2:
+                self._set_fan_threshold_two_speed = True
+            elif self._current_threshold_level == 3:
+                self._set_fan_high_temp_speed = True
+
+        self._old_threshold_level=self._current_threshold_level
+
+    def __set_level_up_down_thresholds(self, chassis):
+        fan_type = chassis.get_chassis_fan_type()
+        match fan_type:
+            case "intake":
+                self._level_up_threshold = [[38,38,38,40,38,84,61],
+                                            [49,51,48,48,50,95,74],
+                                            [52,54,52,53,54,98,78]]
+                self._level_down_threshold = [[33,33,33,34,33,73,53],
+                                              [45,46,45,44,44,88,72],
+                                              [49,51,48,48,50,96,74]]
+            case "exhaust":
+                self._level_up_threshold = [[43,33,38,33,27,55,62],
+                                            [58,45,51,45,36,71,79],
+                                            [61,49,55,50,45,77,83]]
+                self._level_down_threshold = [[35,24,30,26,22,48,52],
+                                              [55,42,49,41,33,67,72],
+                                              [58,45,51,47,39,74,79]]
+            case _:
+                self._level_up_threshold = []
+                self._level_down_threshold = []
+
+    def is_set_fan_default_speed(self):
+        """
+        Retrieves if the temperature is warm up and over high threshold
+        :return: True if the temperature is warm up and over high threshold else False
+        """
+        return self._set_fan_default_speed
+
+    def is_set_fan_threshold_one_speed(self):
+        """
+        Retrieves if the temperature is warm up and over high threshold
+        :return: True if the temperature is warm up and over high threshold else False
+        """
+        return self._set_fan_threshold_one_speed
+
+    def is_set_fan_threshold_two_speed(self):
+        """
+        Retrieves if the temperature is warm up and over high threshold
+        :return: True if the temperature is warm up and over high threshold else False
+        """
+        return self._set_fan_threshold_two_speed
+
+    def is_set_fan_high_temp_speed(self):
+        """
+        Retrieves if the temperature is warm up and over high threshold
+        :return: True if the temperature is warm up and over high threshold else False
+        """
+        return self._set_fan_high_temp_speed
+
+    def is_over_high_critical_threshold(self):
+        """
+        Retrieves if the temperature is over high critical threshold
+        :return: True if the temperature is over high critical threshold else False
+        """
+        return self._over_high_critical_threshold
+
+
+@thermal_json_object('psu_info')
+class PsuInfo(ThermalPolicyInfoBase):
+    """
+    PSU information needed by thermal policy
+    """
+    INFO_NAME = 'psu_info'
+
+    def __init__(self):
+        self._absence_psus = set()
+        self._presence_psus = set()
+        self._status_changed = False
+
+    def collect(self, chassis):
+        """
+        Collect absence and presence PSUs.
+        :param chassis: The chassis object
+        :return:
+        """
+        self._status_changed = False
+        for psu in chassis.get_all_psus():
+            if psu.get_presence() and psu.get_powergood_status() and psu not in self._presence_psus:
+                self._presence_psus.add(psu)
+                self._status_changed = True
+                if psu in self._absence_psus:
+                    self._absence_psus.remove(psu)
+            elif (not psu.get_presence() or not psu.get_powergood_status()) and psu not in self._absence_psus:
+                self._absence_psus.add(psu)
+                self._status_changed = True
+                if psu in self._presence_psus:
+                    self._presence_psus.remove(psu)
+
+    def get_absence_psus(self):
+        """
+        Retrieves presence PSUs
+        :return: A set of absence PSUs
+        """
+        return self._absence_psus
+
+    def get_presence_psus(self):
+        """
+        Retrieves presence PSUs
+        :return: A set of presence fans
+        """
+        return self._presence_psus
+
+    def is_status_changed(self):
+        """
+        Retrieves if the status of PSU information changed
+        :return: True if status changed else False
+        """
+        return self._status_changed
+
+
+@thermal_json_object('chassis_info')
+class ChassisInfo(ThermalPolicyInfoBase):
+    """
+    Chassis information needed by thermal policy
+    """
+    INFO_NAME = 'chassis_info'
+
+    def __init__(self):
+        self._chassis = None
+
+    def collect(self, chassis):
+        """
+        Collect platform chassis.
+        :param chassis: The chassis object
+        :return:
+        """
+        self._chassis = chassis
+
+    def get_chassis(self):
+        """
+        Retrieves platform chassis object
+        :return: A platform chassis object.
+        """
+        return self._chassis

--- a/ixr7220d4/sonic_platform/thermal_manager.py
+++ b/ixr7220d4/sonic_platform/thermal_manager.py
@@ -1,0 +1,57 @@
+"""
+     Nokia IXR7220-D4-36D
+     Module contains an implementation of SONiC Platform Base API and
+     provides the Thermal Manager which are available in the platform
+"""
+try:
+    from sonic_platform_base.sonic_thermal_control.thermal_manager_base import ThermalManagerBase
+    from .thermal_actions import *
+    from .thermal_conditions import *
+    from .thermal_infos import *
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+class ThermalManager(ThermalManagerBase):
+    """Nokia platform-specific Thermal Manager class"""
+    THERMAL_ALGORITHM_CONTROL_PATH = '/var/run/hw-management/config/suspend'
+
+    @classmethod
+    def start_thermal_control_algorithm(cls):
+        """
+        Start thermal control algorithm
+
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        cls._control_thermal_control_algorithm(False)
+
+    @classmethod
+    def stop_thermal_control_algorithm(cls):
+        """
+        Stop thermal control algorithm
+
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        cls._control_thermal_control_algorithm(True)
+
+    @classmethod
+    def _control_thermal_control_algorithm(cls, suspend):
+        """
+        Control thermal control algorithm
+
+        Args:
+            suspend: Bool, indicate suspend the algorithm or not
+
+        Returns:
+            bool: True if set success, False if fail.
+        """
+        status = True
+        write_value = 1 if suspend else 0
+        try:
+            with open(cls.THERMAL_ALGORITHM_CONTROL_PATH, 'w') as control_file:
+                control_file.write(str(write_value))
+        except (ValueError, IOError):
+            status = False
+
+        return status

--- a/ixr7220d4/sonic_platform/watchdog.py
+++ b/ixr7220d4/sonic_platform/watchdog.py
@@ -1,0 +1,198 @@
+"""
+Module contains an implementation of SONiC Platform Base API and
+provides access to hardware watchdog
+"""
+try:
+    import os
+    import fcntl
+    import array
+    from sonic_platform_base.watchdog_base import WatchdogBase
+except ImportError as e:
+    raise ImportError(str(e) + ' - required module not found') from e
+
+""" ioctl constants """
+IO_WRITE = 0x40000000
+IO_READ = 0x80000000
+IO_SIZE_INT = 0x00040000
+IO_READ_WRITE = 0xC0000000
+IO_TYPE_WATCHDOG = ord('W') << 8
+
+WDR_INT = IO_READ | IO_SIZE_INT | IO_TYPE_WATCHDOG
+WDWR_INT = IO_READ_WRITE | IO_SIZE_INT | IO_TYPE_WATCHDOG
+
+""" Watchdog ioctl commands """
+WDIOC_SETOPTIONS = 4 | WDR_INT
+WDIOC_KEEPALIVE = 5 | WDR_INT
+WDIOC_SETTIMEOUT = 6 | WDWR_INT
+WDIOC_GETTIMEOUT = 7 | WDR_INT
+WDIOC_SETPRETIMEOUT = 8 | WDWR_INT
+WDIOC_GETPRETIMEOUT = 9 | WDR_INT
+WDIOC_GETTIMELEFT = 10 | WDR_INT
+
+""" Watchdog status constants """
+WDIOS_DISABLECARD = 0x0001
+WDIOS_ENABLECARD = 0x0002
+
+""" watchdog sysfs """
+WD_SYSFS_PATH = "/sys/class/watchdog/watchdog0/"
+WD_COMMON_ERROR = -1
+
+class WatchdogImplBase(WatchdogBase):
+    """
+    Base class that implements common logic for interacting
+    with watchdog using ioctl commands
+    """
+
+    def __init__(self, wd_device_path):
+        """
+        Open a watchdog handle
+        @param wd_device_path Path to watchdog device
+        """
+        super(WatchdogImplBase, self).__init__()
+
+        self.watchdog=""
+        self.watchdog_path = wd_device_path
+        self.wd_state_reg = WD_SYSFS_PATH+"state"
+        self.wd_timeout_reg = WD_SYSFS_PATH+"timeout"
+        self.wd_timeleft_reg = WD_SYSFS_PATH+"timeleft"
+
+        self.timeout = self._gettimeout()
+
+    def _read_sysfs_file(self, sysfs_file):
+        # On successful read, returns the value read from given
+        # reg_name and on failure returns 'ERR'
+        rv = 'ERR'
+
+        if (not os.path.isfile(sysfs_file)):
+            return rv
+        try:
+            with open(sysfs_file, 'r') as fd:
+                rv = fd.read()
+        except Exception as e:
+            rv = 'ERR'
+
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+        return rv
+
+    def _disablewatchdog(self):
+        """
+        Turn off the watchdog timer
+        """
+
+        req = array.array('h', [WDIOS_DISABLECARD])
+        fcntl.ioctl(self.watchdog, WDIOC_SETOPTIONS, req, False)
+
+    def _enablewatchdog(self):
+        """
+        Turn on the watchdog timer
+        """
+
+        req = array.array('h', [WDIOS_ENABLECARD])
+        fcntl.ioctl(self.watchdog, WDIOC_SETOPTIONS, req, False)
+
+    def _keepalive(self):
+        """
+        Keep alive watchdog timer
+        """
+
+        fcntl.ioctl(self.watchdog, WDIOC_KEEPALIVE)
+
+    def _settimeout(self, seconds):
+        """
+        Set watchdog timer timeout
+        @param seconds - timeout in seconds
+        @return is the actual set timeout
+        """
+
+        req = array.array('I', [seconds])
+        fcntl.ioctl(self.watchdog, WDIOC_SETTIMEOUT, req, True)
+
+        return int(req[0])
+
+    def _gettimeout(self):
+        """
+        Get watchdog timeout
+        @return watchdog timeout
+        """
+        timeout=0
+        timeout=self._read_sysfs_file(self.wd_timeout_reg)
+
+        return timeout
+
+    def _gettimeleft(self):
+        """
+        Get time left before watchdog timer expires
+        @return time left in seconds
+        """
+
+        req = array.array('I', [0])
+        fcntl.ioctl(self.watchdog, WDIOC_GETTIMELEFT, req, True)
+
+        return int(req[0])
+
+    def arm(self, seconds):
+        """
+        Arm the hardware watchdog
+        """
+
+        ret = WD_COMMON_ERROR
+        if (seconds < 0 or seconds > 340 ):
+            return ret
+
+        if not self.watchdog:
+            self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)
+        try:
+            if self.timeout != seconds:
+                self.timeout = self._settimeout(seconds)
+            if self.is_armed():
+                self._keepalive()
+            else:
+                self._enablewatchdog()
+            ret = self.timeout
+        except IOError:
+            pass
+
+        return ret
+
+    def disarm(self):
+        """
+        Disarm the hardware watchdog
+
+        Returns:
+            A boolean, True if watchdog is disarmed successfully, False
+            if not
+        """
+        if not self.watchdog:
+            self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)
+        try:
+            self._disablewatchdog()
+            self.timeout = 0
+        except IOError:
+            return False
+
+        return True
+
+    def is_armed(self):
+        """
+        Implements is_armed WatchdogBase API
+        """
+        status = False
+
+        state = self._read_sysfs_file(self.wd_state_reg)
+        if (state != 'inactive'):
+            status = True
+
+        return status
+
+    def get_remaining_time(self):
+        """
+        Implements get_remaining_time WatchdogBase API
+        """
+
+        timeleft = WD_COMMON_ERROR
+
+        if self.is_armed():
+            timeleft=self._read_sysfs_file(self.wd_timeleft_reg)
+
+        return int(timeleft)


### PR DESCRIPTION
### Why I did it
Add support for NOKIA 7220-IXR-D4-36D platform:

```
Platform: x86_64-nokia_ixr7220_d4-r0
HwSKU: Nokia-IXR7220-D4-36D
ASIC: broadcom
ASIC Count: 1
Port Config: 28x100G + 8x400G
```

### How I did it
1. Add platform related directory `ixr7220d4` in `platform/broadcom/sonic-platform-modules-nokia`
2. Modified related build scripts in `platform/broadcom/sonic-platform-modules-nokia/debian`

### How to verify it
1. Make sure the sonic-buildimage is successful
2. Run this image on x86_64-nokia_ixr7220_d4-r0 and verify all dockers are up and test basic commands like:
- show version
- show platform summary
- show platform syseeprom
- show platform fan
- show platform psustatus
- show platform firmware status
- show platform temperature
- sudo show system-health detail
- show interface status
3. Run OC test with T0 topology.