### PR TITLE
[H6-128]Update on port led, reset reason, 100G and 10G port, etc.

### DIFF
--- a/debian/sonic-platform-nokia-ixr7220h6-128.install
+++ b/debian/sonic-platform-nokia-ixr7220h6-128.install
@@ -4,4 +4,5 @@ ixr7220h6-128/scripts/ports_notify.py usr/local/bin
 ixr7220h6-128/service/h6_128_platform_init.service etc/systemd/system
 ixr7220h6-128/service/bmc_network_init.service etc/systemd/system
 ixr7220h6-128/service/ports_notify.service etc/systemd/system/
+ixr7220h6-128/service/70-bmc-usb-network.rules etc/udev/rules.d
 ixr7220h6-128/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7220_h6_128-r0

--- a/debian/sonic-platform-nokia-ixr7220h6-128.install
+++ b/debian/sonic-platform-nokia-ixr7220h6-128.install
@@ -1,5 +1,7 @@
 ixr7220h6-128/scripts/h6_128_platform_init.sh usr/local/bin
+ixr7220h6-128/scripts/bmc_network_init.sh usr/local/bin
 ixr7220h6-128/scripts/ports_notify.py usr/local/bin
 ixr7220h6-128/service/h6_128_platform_init.service etc/systemd/system
+ixr7220h6-128/service/bmc_network_init.service etc/systemd/system
 ixr7220h6-128/service/ports_notify.service etc/systemd/system/
 ixr7220h6-128/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-nokia_ixr7220_h6_128-r0

--- a/debian/sonic-platform-nokia-ixr7220h6-128.postinst
+++ b/debian/sonic-platform-nokia-ixr7220h6-128.postinst
@@ -4,8 +4,11 @@
 # see: dh_installdeb(1)
 
 chmod a+x /usr/local/bin/h6_128_platform_init.sh
+chmod a+x /usr/local/bin/bmc_network_init.sh
 systemctl enable h6_128_platform_init.service
 systemctl start h6_128_platform_init.service
+systemctl enable bmc_network_init.service
+systemctl start bmc_network_init.service
 chmod a+x /usr/local/bin/ports_notify.py
 systemctl enable ports_notify.service
 systemctl start --no-block ports_notify.service

--- a/debian/sonic-platform-nokia-ixr7220h6-128.postinst
+++ b/debian/sonic-platform-nokia-ixr7220h6-128.postinst
@@ -5,10 +5,13 @@
 
 chmod a+x /usr/local/bin/h6_128_platform_init.sh
 chmod a+x /usr/local/bin/bmc_network_init.sh
+systemctl daemon-reload || true
 systemctl enable h6_128_platform_init.service
 systemctl start h6_128_platform_init.service
+# Bind service activation to usb0 device unit; avoid eager start at package install.
 systemctl enable bmc_network_init.service
-systemctl start bmc_network_init.service
+udevadm control --reload-rules || true
+udevadm trigger --subsystem-match=net || true
 chmod a+x /usr/local/bin/ports_notify.py
 systemctl enable ports_notify.service
 systemctl start --no-block ports_notify.service

--- a/ixr7220h6-128/modules/cb_pld.c
+++ b/ixr7220h6-128/modules/cb_pld.c
@@ -35,7 +35,9 @@
 #define PSU_PRESENT_REG                  0x07
 #define SSD_PRESENT_REG                  0x08
 #define MUX_SEL_REG                      0x0F
+#define RESET_REASON_REG                 0x3B
 #define PSU_POWERGOOD_REG                0x51
+#define CONSOLE_WDT_REG                  0x63
 
 static const unsigned short cpld_address_list[] = {0x60, I2C_CLIENT_END};
 
@@ -131,6 +133,48 @@ static ssize_t show_mux_sel(struct device *dev, struct device_attribute *devattr
     return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
 }
 
+static ssize_t show_reset_cause(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%02x\n", data->reset_cause);
+}
+
+static ssize_t show_console_wdt(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, CONSOLE_WDT_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_console_wdt(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val = 0;
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, CONSOLE_WDT_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+    cpld_i2c_write(data, CONSOLE_WDT_REG, (reg_val | usr_val));
+
+    return count;
+}
+
 // sysfs attributes
 static SENSOR_DEVICE_ATTR(hw_board_version, S_IRUGO, show_hw_board_ver, NULL, 0);
 static SENSOR_DEVICE_ATTR(version, S_IRUGO, show_ver, NULL, 0);
@@ -145,6 +189,8 @@ static SENSOR_DEVICE_ATTR(psu4_pres, S_IRUGO, show_psu_present, NULL, 0);
 static SENSOR_DEVICE_ATTR(ssd1_pres, S_IRUGO, show_ssd_present, NULL, 1);
 static SENSOR_DEVICE_ATTR(ssd2_pres, S_IRUGO, show_ssd_present, NULL, 0);
 static SENSOR_DEVICE_ATTR(mux_sel, S_IRUGO, show_mux_sel, NULL, 0);
+static SENSOR_DEVICE_ATTR(reset_cause, S_IRUGO, show_reset_cause, NULL, 0);
+static SENSOR_DEVICE_ATTR(console_wdt, S_IRUGO | S_IWUSR, show_console_wdt, set_console_wdt, 0);
 
 static struct attribute *cb_pld_attributes[] = {
     &sensor_dev_attr_hw_board_version.dev_attr.attr,
@@ -160,6 +206,8 @@ static struct attribute *cb_pld_attributes[] = {
     &sensor_dev_attr_ssd1_pres.dev_attr.attr,
     &sensor_dev_attr_ssd2_pres.dev_attr.attr,
     &sensor_dev_attr_mux_sel.dev_attr.attr,
+    &sensor_dev_attr_reset_cause.dev_attr.attr,
+    &sensor_dev_attr_console_wdt.dev_attr.attr,
     NULL
 };
 
@@ -196,6 +244,9 @@ static int cb_pld_probe(struct i2c_client *client)
         dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
         goto exit_sysfs_create_group;
     }
+
+    data->reset_cause = cpld_i2c_read(data, RESET_REASON_REG);
+    cpld_i2c_write(data, RESET_REASON_REG, 0xFF);
 
     return 0;
 

--- a/ixr7220h6-128/modules/h6_fan_cpld.c
+++ b/ixr7220h6-128/modules/h6_fan_cpld.c
@@ -303,7 +303,7 @@ static ssize_t set_duty_cycle(struct device *dev, struct device_attribute *da,
 
 	switch (attr->index) {
 	case FAN1_PWM ... FAN8_PWM:
-		reg_val = (value * 100) / 666;
+		reg_val = (value * 100 + 333) / 666;
 		idx = (attr->index - FAN1_PWM);
 
 		mutex_lock(&data->update_lock);

--- a/ixr7220h6-128/modules/port_pld0.c
+++ b/ixr7220h6-128/modules/port_pld0.c
@@ -27,6 +27,7 @@
 #include <linux/delay.h>
 
 #define DRIVER_NAME "port_pld0"
+#define PORT_NUM 32
 
 // REGISTERS ADDRESS MAP
 #define VER_MAJOR_REG           0x00
@@ -36,6 +37,7 @@
 #define SFP_TXDIS_REG           0x18
 #define SFP_RXLOSS_REG          0x20
 #define SFP_MODPRS_REG          0x28
+#define PORT_BRKT_REG0          0x30
 #define PORT_LPMODE_REG0        0x70
 #define PORT_RST_REG0           0x78
 #define PORT_MODPRS_REG0        0x88
@@ -47,6 +49,7 @@ static const unsigned short cpld_address_list[] = {0x74, I2C_CLIENT_END};
 struct cpld_data {
     struct i2c_client *client;
     struct mutex  update_lock;
+    u8 port_en[PORT_NUM];
 };
 
 static int cpld_i2c_read(struct cpld_data *data, u8 reg)
@@ -56,7 +59,8 @@ static int cpld_i2c_read(struct cpld_data *data, u8 reg)
 
     val = i2c_smbus_read_byte_data(client, reg);
     if (val < 0) {
-         dev_warn(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+        dev_warn_ratelimited(&client->dev,
+                              "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
     }
 
     return val;
@@ -67,12 +71,11 @@ static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
     int res = 0;
     struct i2c_client *client = data->client;
 
-    mutex_lock(&data->update_lock);
     res = i2c_smbus_write_byte_data(client, reg, value);
     if (res < 0) {
-        dev_warn(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+        dev_warn_ratelimited(&client->dev,
+                             "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
     }
-    mutex_unlock(&data->update_lock);
 }
 
 static void dump_reg(struct cpld_data *data)
@@ -134,9 +137,6 @@ static ssize_t set_scratch(struct device *dev, struct device_attribute *devattr,
     if (ret != 0) {
         return ret;
     }
-    if (usr_val > 0xFF) {
-        return -EINVAL;
-    }
 
     cpld_i2c_write(data, SCRATCH_REG, usr_val);
 
@@ -172,6 +172,7 @@ static ssize_t set_sfp_tx_en(struct device *dev, struct device_attribute *devatt
     u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
+    int raw;
 
     int ret = kstrtou8(buf, 10, &usr_val);
     if (ret != 0) {
@@ -182,10 +183,17 @@ static ssize_t set_sfp_tx_en(struct device *dev, struct device_attribute *devatt
     }
 
     mask = (~(1 << sda->index)) & 0xFF;
-    reg_val = cpld_i2c_read(data, SFP_TXDIS_REG);
-    reg_val = reg_val & mask;
     usr_val = usr_val << sda->index;
+
+    mutex_lock(&data->update_lock);
+    raw = cpld_i2c_read(data, SFP_TXDIS_REG);
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
     cpld_i2c_write(data, SFP_TXDIS_REG, (reg_val | usr_val));
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -230,6 +238,7 @@ static ssize_t set_port_lpmode(struct device *dev, struct device_attribute *deva
     u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
+    int raw;
 
     int ret = kstrtou8(buf, 10, &usr_val);
     if (ret != 0) {
@@ -240,10 +249,17 @@ static ssize_t set_port_lpmode(struct device *dev, struct device_attribute *deva
     }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_LPMODE_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
     usr_val = usr_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    raw = cpld_i2c_read(data, PORT_LPMODE_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
     cpld_i2c_write(data, PORT_LPMODE_REG0 + (sda->index / 8), (reg_val | usr_val));
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -266,6 +282,7 @@ static ssize_t set_port_rst(struct device *dev, struct device_attribute *devattr
     u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
+    int raw;
 
     int ret = kstrtou8(buf, 10, &usr_val);
     if (ret != 0) {
@@ -276,10 +293,17 @@ static ssize_t set_port_rst(struct device *dev, struct device_attribute *devattr
     }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_RST_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
     usr_val = usr_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    raw = cpld_i2c_read(data, PORT_RST_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
     cpld_i2c_write(data, PORT_RST_REG0 + (sda->index / 8), (reg_val | usr_val));
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -302,7 +326,7 @@ static ssize_t show_modprs_reg(struct device *dev, struct device_attribute *deva
     u8 val = 0;
 
     val = cpld_i2c_read(data, PORT_MODPRS_REG0 + sda->index);
-    
+
     return sprintf(buf, "0x%02x\n", val);
 }
 
@@ -310,11 +334,8 @@ static ssize_t show_port_en(struct device *dev, struct device_attribute *devattr
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
 
-    val = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
-
-    return sprintf(buf, "%d\n", (val>>(sda->index % 8)) & 0x1 ? 1:0);
+    return sprintf(buf, "0x%02x\n", data->port_en[sda->index]);
 }
 
 static ssize_t set_port_en(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
@@ -323,21 +344,56 @@ static ssize_t set_port_en(struct device *dev, struct device_attribute *devattr,
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
     u8 reg_val = 0;
     u8 usr_val = 0;
+    u8 out_val = 0;
     u8 mask;
+    int raw;
 
-    int ret = kstrtou8(buf, 10, &usr_val);
+    int ret = kstrtou8(buf, 16, &usr_val);
     if (ret != 0) {
         return ret;
     }
-    if (usr_val > 1) {
-        return -EINVAL;
-    }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
-    usr_val = usr_val << (sda->index % 8);
-    cpld_i2c_write(data, PORT_ENABLE_REG0 + (sda->index / 8), (reg_val | usr_val));
+    if (usr_val != 0) out_val = 1;
+    out_val = out_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    data->port_en[sda->index] = usr_val;
+    raw = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
+    cpld_i2c_write(data, PORT_ENABLE_REG0 + (sda->index / 8), (reg_val | out_val));
+    mutex_unlock(&data->update_lock);
+
+    return count;
+}
+
+static ssize_t show_port_brkt(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, PORT_BRKT_REG0+sda->index);
+
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+static ssize_t set_port_brkt(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+
+    cpld_i2c_write(data, PORT_BRKT_REG0+sda->index, usr_val);
 
     return count;
 }
@@ -488,6 +544,39 @@ static SENSOR_DEVICE_ATTR(port_30_en, S_IRUGO | S_IWUSR, show_port_en, set_port_
 static SENSOR_DEVICE_ATTR(port_31_en, S_IRUGO | S_IWUSR, show_port_en, set_port_en, 30);
 static SENSOR_DEVICE_ATTR(port_32_en, S_IRUGO | S_IWUSR, show_port_en, set_port_en, 31);
 
+static SENSOR_DEVICE_ATTR(port_1_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 0);
+static SENSOR_DEVICE_ATTR(port_2_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 1);
+static SENSOR_DEVICE_ATTR(port_3_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 2);
+static SENSOR_DEVICE_ATTR(port_4_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 3);
+static SENSOR_DEVICE_ATTR(port_5_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 4);
+static SENSOR_DEVICE_ATTR(port_6_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 5);
+static SENSOR_DEVICE_ATTR(port_7_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 6);
+static SENSOR_DEVICE_ATTR(port_8_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 7);
+static SENSOR_DEVICE_ATTR(port_9_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 8);
+static SENSOR_DEVICE_ATTR(port_10_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 9);
+static SENSOR_DEVICE_ATTR(port_11_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 10);
+static SENSOR_DEVICE_ATTR(port_12_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 11);
+static SENSOR_DEVICE_ATTR(port_13_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 12);
+static SENSOR_DEVICE_ATTR(port_14_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 13);
+static SENSOR_DEVICE_ATTR(port_15_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 14);
+static SENSOR_DEVICE_ATTR(port_16_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 15);
+static SENSOR_DEVICE_ATTR(port_17_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 16);
+static SENSOR_DEVICE_ATTR(port_18_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 17);
+static SENSOR_DEVICE_ATTR(port_19_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 18);
+static SENSOR_DEVICE_ATTR(port_20_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 19);
+static SENSOR_DEVICE_ATTR(port_21_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 20);
+static SENSOR_DEVICE_ATTR(port_22_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 21);
+static SENSOR_DEVICE_ATTR(port_23_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 22);
+static SENSOR_DEVICE_ATTR(port_24_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 23);
+static SENSOR_DEVICE_ATTR(port_25_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 24);
+static SENSOR_DEVICE_ATTR(port_26_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 25);
+static SENSOR_DEVICE_ATTR(port_27_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 26);
+static SENSOR_DEVICE_ATTR(port_28_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 27);
+static SENSOR_DEVICE_ATTR(port_29_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 28);
+static SENSOR_DEVICE_ATTR(port_30_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 29);
+static SENSOR_DEVICE_ATTR(port_31_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 30);
+static SENSOR_DEVICE_ATTR(port_32_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 31);
+
 static struct attribute *port_pld0_attributes[] = {
     &sensor_dev_attr_version.dev_attr.attr,
     &sensor_dev_attr_scratch.dev_attr.attr,
@@ -634,6 +723,39 @@ static struct attribute *port_pld0_attributes[] = {
     &sensor_dev_attr_port_31_en.dev_attr.attr,
     &sensor_dev_attr_port_32_en.dev_attr.attr,
 
+    &sensor_dev_attr_port_1_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_2_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_3_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_4_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_5_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_6_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_7_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_8_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_9_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_10_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_11_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_12_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_13_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_14_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_15_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_16_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_17_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_18_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_19_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_20_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_21_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_22_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_23_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_24_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_25_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_26_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_27_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_28_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_29_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_30_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_31_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_32_brkt.dev_attr.attr,
+
     NULL
 };
 
@@ -688,7 +810,11 @@ static int port_pld0_probe(struct i2c_client *client)
     cpld_i2c_write(data, PORT_RST_REG0+3, 0xFF);
     dev_info(&client->dev, "[PORT_PLD0]PORTs reset done.\n");
     dump_reg(data);
-    
+    cpld_i2c_write(data, PORT_ENABLE_REG0, 0x0);
+    cpld_i2c_write(data, PORT_ENABLE_REG0+1, 0x0);
+    cpld_i2c_write(data, PORT_ENABLE_REG0+2, 0x0);
+    cpld_i2c_write(data, PORT_ENABLE_REG0+3, 0x0);
+
     return 0;
 
 exit_sysfs_create_group:

--- a/ixr7220h6-128/modules/port_pld1.c
+++ b/ixr7220h6-128/modules/port_pld1.c
@@ -27,15 +27,18 @@
 #include <linux/delay.h>
 
 #define DRIVER_NAME "port_pld1"
+#define PORT_NUM 33
 
 // REGISTERS ADDRESS MAP
 #define VER_MAJOR_REG           0x00
 #define VER_MINOR_REG           0x01
 #define SCRATCH_REG             0x04
+#define PORT_BRKT_REG0          0x30
 #define PORT_LPMODE_REG0        0x70
 #define PORT_RST_REG0           0x78
 #define PORT_MODPRS_REG0        0x88
 #define PORT_PWGOOD_REG0        0x90
+#define PORT33_ENABLE_REG       0x96
 #define PORT_ENABLE_REG0        0x98
 
 static const unsigned short cpld_address_list[] = {0x75, I2C_CLIENT_END};
@@ -43,6 +46,7 @@ static const unsigned short cpld_address_list[] = {0x75, I2C_CLIENT_END};
 struct cpld_data {
     struct i2c_client *client;
     struct mutex  update_lock;
+    u8 port_en[PORT_NUM];
 };
 
 static int cpld_i2c_read(struct cpld_data *data, u8 reg)
@@ -52,7 +56,8 @@ static int cpld_i2c_read(struct cpld_data *data, u8 reg)
 
     val = i2c_smbus_read_byte_data(client, reg);
     if (val < 0) {
-         dev_warn(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+        dev_warn_ratelimited(&client->dev,
+                              "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
     }
 
     return val;
@@ -63,12 +68,11 @@ static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
     int res = 0;
     struct i2c_client *client = data->client;
 
-    mutex_lock(&data->update_lock);
     res = i2c_smbus_write_byte_data(client, reg, value);
     if (res < 0) {
-        dev_warn(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+        dev_warn_ratelimited(&client->dev,
+                             "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
     }
-    mutex_unlock(&data->update_lock);
 }
 
 static void dump_reg(struct cpld_data *data)
@@ -130,9 +134,6 @@ static ssize_t set_scratch(struct device *dev, struct device_attribute *devattr,
     if (ret != 0) {
         return ret;
     }
-    if (usr_val > 0xFF) {
-        return -EINVAL;
-    }
 
     cpld_i2c_write(data, SCRATCH_REG, usr_val);
 
@@ -157,6 +158,7 @@ static ssize_t set_port_lpmode(struct device *dev, struct device_attribute *deva
     u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
+    int raw;
 
     int ret = kstrtou8(buf, 10, &usr_val);
     if (ret != 0) {
@@ -167,10 +169,17 @@ static ssize_t set_port_lpmode(struct device *dev, struct device_attribute *deva
     }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_LPMODE_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
     usr_val = usr_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    raw = cpld_i2c_read(data, PORT_LPMODE_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
     cpld_i2c_write(data, PORT_LPMODE_REG0 + (sda->index / 8), (reg_val | usr_val));
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -193,6 +202,7 @@ static ssize_t set_port_rst(struct device *dev, struct device_attribute *devattr
     u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
+    int raw;
 
     int ret = kstrtou8(buf, 10, &usr_val);
     if (ret != 0) {
@@ -203,10 +213,17 @@ static ssize_t set_port_rst(struct device *dev, struct device_attribute *devattr
     }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_RST_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
     usr_val = usr_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    raw = cpld_i2c_read(data, PORT_RST_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
     cpld_i2c_write(data, PORT_RST_REG0 + (sda->index / 8), (reg_val | usr_val));
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -229,7 +246,7 @@ static ssize_t show_modprs_reg(struct device *dev, struct device_attribute *deva
     u8 val = 0;
 
     val = cpld_i2c_read(data, PORT_MODPRS_REG0 + sda->index);
-    
+
     return sprintf(buf, "0x%02x\n", val);
 }
 
@@ -237,11 +254,8 @@ static ssize_t show_port_en(struct device *dev, struct device_attribute *devattr
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
 
-    val = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
-
-    return sprintf(buf, "%d\n", (val>>(sda->index % 8)) & 0x1 ? 1:0);
+    return sprintf(buf, "0x%02x\n", data->port_en[sda->index]);
 }
 
 static ssize_t set_port_en(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
@@ -250,21 +264,94 @@ static ssize_t set_port_en(struct device *dev, struct device_attribute *devattr,
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
     u8 reg_val = 0;
     u8 usr_val = 0;
+    u8 out_val = 0;
     u8 mask;
+    int raw;
 
-    int ret = kstrtou8(buf, 10, &usr_val);
+    int ret = kstrtou8(buf, 16, &usr_val);
     if (ret != 0) {
         return ret;
     }
-    if (usr_val > 1) {
-        return -EINVAL;
-    }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
-    usr_val = usr_val << (sda->index % 8);
-    cpld_i2c_write(data, PORT_ENABLE_REG0 + (sda->index / 8), (reg_val | usr_val));
+    if (usr_val != 0) out_val = 1;
+    out_val = out_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    data->port_en[sda->index] = usr_val;
+    raw = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
+    cpld_i2c_write(data, PORT_ENABLE_REG0 + (sda->index / 8), (reg_val | out_val));
+    mutex_unlock(&data->update_lock);
+
+    return count;
+}
+
+static ssize_t show_port33_en(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+
+    return sprintf(buf, "0x%02x\n", data->port_en[32]);
+}
+
+static ssize_t set_port33_en(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 reg_val = 0;
+    u8 usr_val = 0;
+    u8 out_val = 0;
+    u8 mask;
+    int raw;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+
+    mask = 0xFE;
+    if (usr_val != 0) out_val = 1;
+
+    mutex_lock(&data->update_lock);
+    data->port_en[32] = usr_val;
+    raw = cpld_i2c_read(data, PORT33_ENABLE_REG);
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
+    cpld_i2c_write(data, PORT33_ENABLE_REG, (reg_val | out_val));
+    mutex_unlock(&data->update_lock);
+
+    return count;
+}
+
+static ssize_t show_port_brkt(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, PORT_BRKT_REG0+sda->index);
+
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+static ssize_t set_port_brkt(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+
+    cpld_i2c_write(data, PORT_BRKT_REG0+sda->index, usr_val);
 
     return count;
 }
@@ -412,6 +499,40 @@ static SENSOR_DEVICE_ATTR(port_29_en, S_IRUGO | S_IWUSR, show_port_en, set_port_
 static SENSOR_DEVICE_ATTR(port_30_en, S_IRUGO | S_IWUSR, show_port_en, set_port_en, 29);
 static SENSOR_DEVICE_ATTR(port_31_en, S_IRUGO | S_IWUSR, show_port_en, set_port_en, 30);
 static SENSOR_DEVICE_ATTR(port_32_en, S_IRUGO | S_IWUSR, show_port_en, set_port_en, 31);
+static SENSOR_DEVICE_ATTR(port_33_en, S_IRUGO | S_IWUSR, show_port33_en, set_port33_en, 0);
+
+static SENSOR_DEVICE_ATTR(port_1_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 0);
+static SENSOR_DEVICE_ATTR(port_2_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 1);
+static SENSOR_DEVICE_ATTR(port_3_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 2);
+static SENSOR_DEVICE_ATTR(port_4_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 3);
+static SENSOR_DEVICE_ATTR(port_5_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 4);
+static SENSOR_DEVICE_ATTR(port_6_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 5);
+static SENSOR_DEVICE_ATTR(port_7_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 6);
+static SENSOR_DEVICE_ATTR(port_8_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 7);
+static SENSOR_DEVICE_ATTR(port_9_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 8);
+static SENSOR_DEVICE_ATTR(port_10_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 9);
+static SENSOR_DEVICE_ATTR(port_11_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 10);
+static SENSOR_DEVICE_ATTR(port_12_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 11);
+static SENSOR_DEVICE_ATTR(port_13_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 12);
+static SENSOR_DEVICE_ATTR(port_14_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 13);
+static SENSOR_DEVICE_ATTR(port_15_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 14);
+static SENSOR_DEVICE_ATTR(port_16_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 15);
+static SENSOR_DEVICE_ATTR(port_17_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 16);
+static SENSOR_DEVICE_ATTR(port_18_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 17);
+static SENSOR_DEVICE_ATTR(port_19_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 18);
+static SENSOR_DEVICE_ATTR(port_20_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 19);
+static SENSOR_DEVICE_ATTR(port_21_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 20);
+static SENSOR_DEVICE_ATTR(port_22_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 21);
+static SENSOR_DEVICE_ATTR(port_23_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 22);
+static SENSOR_DEVICE_ATTR(port_24_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 23);
+static SENSOR_DEVICE_ATTR(port_25_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 24);
+static SENSOR_DEVICE_ATTR(port_26_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 25);
+static SENSOR_DEVICE_ATTR(port_27_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 26);
+static SENSOR_DEVICE_ATTR(port_28_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 27);
+static SENSOR_DEVICE_ATTR(port_29_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 28);
+static SENSOR_DEVICE_ATTR(port_30_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 29);
+static SENSOR_DEVICE_ATTR(port_31_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 30);
+static SENSOR_DEVICE_ATTR(port_32_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 31);
 
 static struct attribute *port_pld1_attributes[] = {
     &sensor_dev_attr_version.dev_attr.attr,
@@ -556,6 +677,40 @@ static struct attribute *port_pld1_attributes[] = {
     &sensor_dev_attr_port_30_en.dev_attr.attr,
     &sensor_dev_attr_port_31_en.dev_attr.attr,
     &sensor_dev_attr_port_32_en.dev_attr.attr,
+    &sensor_dev_attr_port_33_en.dev_attr.attr,
+
+    &sensor_dev_attr_port_1_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_2_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_3_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_4_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_5_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_6_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_7_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_8_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_9_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_10_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_11_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_12_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_13_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_14_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_15_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_16_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_17_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_18_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_19_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_20_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_21_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_22_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_23_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_24_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_25_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_26_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_27_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_28_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_29_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_30_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_31_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_32_brkt.dev_attr.attr,
 
     NULL
 };
@@ -611,7 +766,12 @@ static int port_pld1_probe(struct i2c_client *client)
     cpld_i2c_write(data, PORT_RST_REG0+3, 0xFF);
     dev_info(&client->dev, "[PORT_PLD1]PORTs reset done.\n");
     dump_reg(data);
-    
+    cpld_i2c_write(data, PORT_ENABLE_REG0, 0x0);
+    cpld_i2c_write(data, PORT_ENABLE_REG0+1, 0x0);
+    cpld_i2c_write(data, PORT_ENABLE_REG0+2, 0x0);
+    cpld_i2c_write(data, PORT_ENABLE_REG0+3, 0x0);
+    cpld_i2c_write(data, PORT33_ENABLE_REG, 0x0);
+
     return 0;
 
 exit_sysfs_create_group:

--- a/ixr7220h6-128/modules/port_pld2.c
+++ b/ixr7220h6-128/modules/port_pld2.c
@@ -27,11 +27,13 @@
 #include <linux/delay.h>
 
 #define DRIVER_NAME "port_pld2"
+#define PORT_NUM 16
 
 // REGISTERS ADDRESS MAP
 #define VER_MAJOR_REG           0x00
 #define VER_MINOR_REG           0x01
 #define SCRATCH_REG             0x04
+#define PORT_BRKT_REG0          0x30
 #define PORT_LPMODE_REG0        0x70
 #define PORT_EFUSE_REG0         0x72
 #define PORT_RST_REG0           0x78
@@ -45,6 +47,7 @@ struct cpld_data {
     struct i2c_client *client;
     struct mutex  update_lock;
     int port_efuse;
+    u8 port_en[PORT_NUM];
 };
 
 static int cpld_i2c_read(struct cpld_data *data, u8 reg)
@@ -54,7 +57,8 @@ static int cpld_i2c_read(struct cpld_data *data, u8 reg)
 
     val = i2c_smbus_read_byte_data(client, reg);
     if (val < 0) {
-         dev_warn(&client->dev, "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+        dev_warn_ratelimited(&client->dev,
+                              "CPLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
     }
 
     return val;
@@ -65,12 +69,11 @@ static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
     int res = 0;
     struct i2c_client *client = data->client;
 
-    mutex_lock(&data->update_lock);
     res = i2c_smbus_write_byte_data(client, reg, value);
     if (res < 0) {
-        dev_warn(&client->dev, "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+        dev_warn_ratelimited(&client->dev,
+                             "CPLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
     }
-    mutex_unlock(&data->update_lock);
 }
 
 static void dump_reg(struct cpld_data *data)
@@ -124,9 +127,6 @@ static ssize_t set_scratch(struct device *dev, struct device_attribute *devattr,
     if (ret != 0) {
         return ret;
     }
-    if (usr_val > 0xFF) {
-        return -EINVAL;
-    }
 
     cpld_i2c_write(data, SCRATCH_REG, usr_val);
 
@@ -151,6 +151,7 @@ static ssize_t set_port_lpmode(struct device *dev, struct device_attribute *deva
     u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
+    int raw;
 
     int ret = kstrtou8(buf, 10, &usr_val);
     if (ret != 0) {
@@ -161,10 +162,17 @@ static ssize_t set_port_lpmode(struct device *dev, struct device_attribute *deva
     }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_LPMODE_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
     usr_val = usr_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    raw = cpld_i2c_read(data, PORT_LPMODE_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
     cpld_i2c_write(data, PORT_LPMODE_REG0 + (sda->index / 8), (reg_val | usr_val));
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -187,6 +195,7 @@ static ssize_t set_port_rst(struct device *dev, struct device_attribute *devattr
     u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
+    int raw;
 
     int ret = kstrtou8(buf, 10, &usr_val);
     if (ret != 0) {
@@ -197,10 +206,17 @@ static ssize_t set_port_rst(struct device *dev, struct device_attribute *devattr
     }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_RST_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
     usr_val = usr_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    raw = cpld_i2c_read(data, PORT_RST_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
     cpld_i2c_write(data, PORT_RST_REG0 + (sda->index / 8), (reg_val | usr_val));
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -223,14 +239,14 @@ static ssize_t show_modprs_reg(struct device *dev, struct device_attribute *deva
     u8 val = 0;
 
     val = cpld_i2c_read(data, PORT_MODPRS_REG0 + sda->index);
-    
+
     return sprintf(buf, "0x%02x\n", val);
 }
 
 static ssize_t show_port_efuse(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
-    
+
     return sprintf(buf, "%s\n", (data->port_efuse) ? "Enabled":"Disabled");
 }
 
@@ -239,19 +255,24 @@ static ssize_t set_port_efuse(struct device *dev, struct device_attribute *devat
     struct cpld_data *data = dev_get_drvdata(dev);
     const char *str_en = "Enable\n";
     const char *str_dis = "Disable\n";
-    
+    u8 reg_val = 0xFF;
+    u8 efuse_val = 1;
+
     if (strcmp(buf, str_en) == 0) {
-        cpld_i2c_write(data, PORT_EFUSE_REG0, 0xFF);
-        cpld_i2c_write(data, PORT_EFUSE_REG0+1, 0xFF);
-        data->port_efuse = 1;
+        reg_val = 0xFF;
+        efuse_val = 1;
     }
     else if (strcmp(buf, str_dis) == 0) {
-        cpld_i2c_write(data, PORT_EFUSE_REG0, 0x0);
-        cpld_i2c_write(data, PORT_EFUSE_REG0+1, 0x0);
-        data->port_efuse = 0;
+        reg_val = 0;
+        efuse_val = 0;
     }
     else
         return -EINVAL;
+    mutex_lock(&data->update_lock);
+    cpld_i2c_write(data, PORT_EFUSE_REG0, reg_val);
+    cpld_i2c_write(data, PORT_EFUSE_REG0+1, reg_val);
+    data->port_efuse = efuse_val;
+    mutex_unlock(&data->update_lock);
 
     return count;
 }
@@ -260,11 +281,8 @@ static ssize_t show_port_en(struct device *dev, struct device_attribute *devattr
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
 
-    val = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
-
-    return sprintf(buf, "%d\n", (val>>(sda->index % 8)) & 0x1 ? 1:0);
+    return sprintf(buf, "0x%02x\n", data->port_en[sda->index]);
 }
 
 static ssize_t set_port_en(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
@@ -273,21 +291,56 @@ static ssize_t set_port_en(struct device *dev, struct device_attribute *devattr,
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
     u8 reg_val = 0;
     u8 usr_val = 0;
+    u8 out_val = 0;
     u8 mask;
+    int raw;
 
-    int ret = kstrtou8(buf, 10, &usr_val);
+    int ret = kstrtou8(buf, 16, &usr_val);
     if (ret != 0) {
         return ret;
     }
-    if (usr_val > 1) {
-        return -EINVAL;
-    }
 
     mask = (~(1 << (sda->index % 8))) & 0xFF;
-    reg_val = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
-    reg_val = reg_val & mask;
-    usr_val = usr_val << (sda->index % 8);
-    cpld_i2c_write(data, PORT_ENABLE_REG0 + (sda->index / 8), (reg_val | usr_val));
+    if (usr_val != 0) out_val = 1;
+    out_val = out_val << (sda->index % 8);
+
+    mutex_lock(&data->update_lock);
+    data->port_en[sda->index] = usr_val;
+    raw = cpld_i2c_read(data, PORT_ENABLE_REG0 + (sda->index / 8));
+    if (raw < 0) {
+        mutex_unlock(&data->update_lock);
+        return raw;
+    }
+    reg_val = (u8)raw & mask;
+    cpld_i2c_write(data, PORT_ENABLE_REG0 + (sda->index / 8), (reg_val | out_val));
+    mutex_unlock(&data->update_lock);
+
+    return count;
+}
+
+static ssize_t show_port_brkt(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, PORT_BRKT_REG0+sda->index);
+
+    return sprintf(buf, "0x%02x\n", val);
+}
+
+static ssize_t set_port_brkt(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 usr_val = 0;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+
+    cpld_i2c_write(data, PORT_BRKT_REG0+sda->index, usr_val);
 
     return count;
 }
@@ -369,6 +422,23 @@ static SENSOR_DEVICE_ATTR(port_16_en, S_IRUGO | S_IWUSR, show_port_en, set_port_
 
 static SENSOR_DEVICE_ATTR(port_efuse, S_IRUGO | S_IWUSR, show_port_efuse, set_port_efuse, 0);
 
+static SENSOR_DEVICE_ATTR(port_1_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 0);
+static SENSOR_DEVICE_ATTR(port_2_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 1);
+static SENSOR_DEVICE_ATTR(port_3_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 2);
+static SENSOR_DEVICE_ATTR(port_4_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 3);
+static SENSOR_DEVICE_ATTR(port_5_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 4);
+static SENSOR_DEVICE_ATTR(port_6_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 5);
+static SENSOR_DEVICE_ATTR(port_7_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 6);
+static SENSOR_DEVICE_ATTR(port_8_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 7);
+static SENSOR_DEVICE_ATTR(port_9_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 8);
+static SENSOR_DEVICE_ATTR(port_10_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 9);
+static SENSOR_DEVICE_ATTR(port_11_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 10);
+static SENSOR_DEVICE_ATTR(port_12_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 11);
+static SENSOR_DEVICE_ATTR(port_13_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 12);
+static SENSOR_DEVICE_ATTR(port_14_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 13);
+static SENSOR_DEVICE_ATTR(port_15_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 14);
+static SENSOR_DEVICE_ATTR(port_16_brkt, S_IRUGO | S_IWUSR, show_port_brkt, set_port_brkt, 15);
+
 static struct attribute *port_pld2_attributes[] = {
     &sensor_dev_attr_version.dev_attr.attr,
     &sensor_dev_attr_scratch.dev_attr.attr,
@@ -446,6 +516,23 @@ static struct attribute *port_pld2_attributes[] = {
 
     &sensor_dev_attr_port_efuse.dev_attr.attr,
 
+    &sensor_dev_attr_port_1_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_2_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_3_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_4_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_5_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_6_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_7_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_8_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_9_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_10_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_11_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_12_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_13_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_14_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_15_brkt.dev_attr.attr,
+    &sensor_dev_attr_port_16_brkt.dev_attr.attr,
+
     NULL
 };
 
@@ -482,7 +569,7 @@ static int port_pld2_probe(struct i2c_client *client)
         dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
         goto exit_sysfs_create_group;
     }
-    
+
     dump_reg(data);
     cpld_i2c_write(data, PORT_EFUSE_REG0, 0xFF);
     cpld_i2c_write(data, PORT_EFUSE_REG0+1, 0xFF);
@@ -496,7 +583,10 @@ static int port_pld2_probe(struct i2c_client *client)
     cpld_i2c_write(data, PORT_RST_REG0+1, 0xFF);
     dev_info(&client->dev, "[PORT_PLD2]PORTs reset done.\n");
     dump_reg(data);
-    
+    cpld_i2c_write(data, PORT_ENABLE_REG0, 0x0);
+    cpld_i2c_write(data, PORT_ENABLE_REG0+1, 0x0);
+    data->port_efuse = 1;
+
     return 0;
 
 exit_sysfs_create_group:

--- a/ixr7220h6-128/scripts/bmc_network_init.sh
+++ b/ixr7220h6-128/scripts/bmc_network_init.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+CONFIG_FILE="/etc/sonic/bmc_config.json"
+
+check_jq() {
+    if ! command -v jq &> /dev/null; then
+        logger -t bmc-network "Error: 'jq' is not installed. Please install it to parse JSON."
+        echo "Error: 'jq' is not installed. Please install it to parse JSON." >&2
+        exit 1
+    fi
+}
+
+check_jq
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    logger -t bmc-network "Error: Configuration file not found at $CONFIG_FILE"
+    echo "Error: Configuration file not found at $CONFIG_FILE" >&2
+    exit 1
+fi
+
+BMC_IF_NAME=$(jq -r '.bmc_if_name' "$CONFIG_FILE")
+BMC_IF_ADDR=$(jq -r '.bmc_if_addr' "$CONFIG_FILE")
+BMC_NET_MASK=$(jq -r '.bmc_net_mask' "$CONFIG_FILE")
+
+if [ -z "$BMC_IF_NAME" ] || [ -z "$BMC_IF_ADDR" ] || [ -z "$BMC_NET_MASK" ]; then
+    logger -t bmc-network "Error: Failed to extract all required values from $CONFIG_FILE. Check JSON format."
+    echo "Error: Failed to extract all required values from $CONFIG_FILE. Check JSON format." >&2
+    exit 1
+fi
+
+echo "  bmc_if_name: $BMC_IF_NAME" >&2
+echo "  bmc_if_addr: $BMC_IF_ADDR" >&2
+echo "  bmc_net_mask: $BMC_NET_MASK" >&2
+
+if [ "$BMC_IF_NAME" != "usb0" ]; then
+    echo "Renaming interface 'usb0' to '$BMC_IF_NAME'..." >&2
+    if ip link show usb0 &> /dev/null; then
+        ip link set usb0 name "$BMC_IF_NAME"
+        if [ $? -eq 0 ]; then
+            echo "Interface 'usb0' successfully renamed to '$BMC_IF_NAME'." >&2
+        else
+            logger -t bmc-network "Error: Failed to rename 'usb0' to '$BMC_IF_NAME'."
+            echo "Error: Failed to rename 'usb0' to '$BMC_IF_NAME'." >&2
+            exit 1
+        fi
+    else
+        logger -t bmc-network "Warning: Interface 'usb0' not found. Skipping rename."
+        echo "Warning: Interface 'usb0' not found. Skipping rename." >&2
+        exit 1
+    fi
+else
+    echo "Interface name is already 'usb0'. No rename needed." >&2
+fi
+
+echo "Configuring interface '$BMC_IF_NAME' with IP '$BMC_IF_ADDR' and netmask '$BMC_NET_MASK'..." >&2
+ifconfig "$BMC_IF_NAME" "$BMC_IF_ADDR" netmask "$BMC_NET_MASK" up
+
+if [ $? -eq 0 ]; then
+    echo "Interface '$BMC_IF_NAME' successfully configured." >&2
+    echo "Current configuration for '$BMC_IF_NAME':" >&2
+    ip addr show "$BMC_IF_NAME" >&2
+else
+    logger -t bmc-network "Error: Failed to configure interface '$BMC_IF_NAME'."
+    echo "Error: Failed to configure interface '$BMC_IF_NAME'." >&2
+    exit 1
+fi
+
+echo "BMC service finished." >&2

--- a/ixr7220h6-128/scripts/bmc_network_init.sh
+++ b/ixr7220h6-128/scripts/bmc_network_init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONFIG_FILE="/etc/sonic/bmc_config.json"
+CONFIG_FILE="/etc/sonic/bmc.json"
 
 check_jq() {
     if ! command -v jq &> /dev/null; then
@@ -12,7 +12,7 @@ check_jq() {
 
 check_jq
 
-if [ ! -f "$CONFIG_FILE" ]; then
+if [ -z "$CONFIG_FILE" ]; then
     logger -t bmc-network "Error: Configuration file not found at $CONFIG_FILE"
     echo "Error: Configuration file not found at $CONFIG_FILE" >&2
     exit 1
@@ -43,9 +43,11 @@ if [ "$BMC_IF_NAME" != "usb0" ]; then
             echo "Error: Failed to rename 'usb0' to '$BMC_IF_NAME'." >&2
             exit 1
         fi
+    elif ip link show "$BMC_IF_NAME" &> /dev/null; then
+        echo "Interface '$BMC_IF_NAME' already exists. Skipping rename." >&2
     else
-        logger -t bmc-network "Warning: Interface 'usb0' not found. Skipping rename."
-        echo "Warning: Interface 'usb0' not found. Skipping rename." >&2
+        logger -t bmc-network "Error: Neither 'usb0' nor '$BMC_IF_NAME' found. Cannot configure BMC network."
+        echo "Error: Neither 'usb0' nor '$BMC_IF_NAME' found. Cannot configure BMC network." >&2
         exit 1
     fi
 else

--- a/ixr7220h6-128/scripts/h6_128_platform_init.sh
+++ b/ixr7220h6-128/scripts/h6_128_platform_init.sh
@@ -10,7 +10,7 @@ load_kernel_drivers() {
     rmmod i2c-piix4
     rmmod i2c_designware_platform
     modprobe igb
-#    modprobe bnxt_en
+    modprobe bnxt_en
     modprobe i2c_designware_platform
 
     modprobe i2c-i801
@@ -128,7 +128,15 @@ for index in {2..129}; do
 	echo optoe3 0x50 > /sys/bus/i2c/devices/i2c-${index}/new_device
 done
 echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-130/new_device
-echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-131/new_device
+
+i2cset -y 132 0x61 0x06 0x18
+i2cset -y 132 0x61 0x0f 0x01
+i2cset -y 132 0x61 0x16 0x01
+i2cset -y 132 0x61 0x11 0x80
+i2cset -y 132 0x61 0x18 0x80
+i2cset -y 132 0x61 0x23 0x00
+i2cset -y 132 0x61 0x2d 0x00
+ip link set eth1 up
 
 for ch in {1..8}; do
     echo 60 > /sys/bus/i2c/devices/145-0032/hwmon/hwmon*/fan${ch}_pwm

--- a/ixr7220h6-128/scripts/ports_notify.py
+++ b/ixr7220h6-128/scripts/ports_notify.py
@@ -7,7 +7,7 @@
 try:
     from swsscommon import swsscommon
     from sonic_py_common import daemon_base, logger
-    from sonic_platform.sysfs import write_sysfs_file
+    from sonic_platform.sysfs import write_sysfs_file, read_sysfs_file
 except ImportError as e:
     raise ImportError (str(e) + " - required module not found")
 
@@ -15,7 +15,7 @@ SYSLOG_IDENTIFIER = "ports_notify"
 
 SELECT_TIMEOUT_MSECS = 1000
 
-PORT_END = 128
+PORT_END = 129
 SYSFS_DIR = "/sys/bus/i2c/devices/{}/"
 PORTPLD_ADDR = ["153-0076", "154-0076", "149-0074", "150-0075", "151-0073", "152-0073"]
 ADDR_IDX = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
@@ -29,6 +29,7 @@ PORT_IDX = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,1,2,3,4,5,6,7,8,9,10,11,12,13
 
 # Global logger class instance
 sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+# sonic_logger.set_min_log_priority_info()
 
 def wait_for_port_init_done():
     # Connect to APPL_DB and subscribe to PORT table notifications
@@ -56,7 +57,7 @@ def subscribe_port_config_change():
     sel = swsscommon.Select()
     config_db = daemon_base.db_connect("CONFIG_DB")
     port_tbl = swsscommon.SubscriberStateTable(config_db, swsscommon.CFG_PORT_TABLE_NAME)
-    port_tbl.filter = ['admin_status']
+    port_tbl.filter = ['admin_status', 'speed']
     sel.addSelectable(port_tbl)
     return sel, port_tbl
 
@@ -81,24 +82,46 @@ def handle_port_config_change(sel, port_config, logger):
         if fvp is not None:
             fvp = dict(fvp)
 
-            if 'admin_status' in fvp:
-                if 'index' in fvp:
-                    port_index = int(fvp['index'])
-                    if port_index in range(1, PORT_END+1):
-                        pld_path = SYSFS_DIR.format(PORTPLD_ADDR[ADDR_IDX[port_index-1]])
-                        pld_port_idx = PORT_IDX[port_index-1]
-                        file_name = pld_path + f"port_{pld_port_idx}_en"
-                    else:
-                        logger.log_warning(f"Wrong port index {port_index} for port {port_name}")
-                        continue
+            if 'index' in fvp:
+                port_index = int(fvp['index'])
+                if port_index in range(1, PORT_END+1):
+                    pld_path = SYSFS_DIR.format(PORTPLD_ADDR[ADDR_IDX[port_index-1]])
+                    pld_port_idx = PORT_IDX[port_index-1]
+                    admin_file_name = pld_path + f"port_{pld_port_idx}_en"
+                    brkt_file_name = pld_path + f"port_{pld_port_idx}_brkt"
                 else:
-                    logger.log_warning(f"Wrong index from port {port_name}: {fvp}")
+                    logger.log_warning(f"Wrong port index {port_index} for port {port_name}")
                     continue
+            else:
+                logger.log_warning(f"Wrong index from port {port_name}: {fvp}")
+                continue
 
-                if fvp['admin_status'] == 'up':
-                    write_sysfs_file(file_name, '1')
-                elif fvp['admin_status'] == 'down':
-                    write_sysfs_file(file_name, '0')
+            if 'admin_status' in fvp:
+                if 'speed' in fvp and fvp['speed'] in ('100000', '200000', '400000', '800000'):
+                    if 'subport' in fvp and fvp['subport'] == '0':
+                        if fvp['admin_status'] == 'up':
+                            write_sysfs_file(admin_file_name, '0xff')
+                        elif fvp['admin_status'] == 'down':
+                            write_sysfs_file(admin_file_name, '0x0')
+                    else:
+                        speed = int(fvp['speed'])
+                        mask = 0xff >> ((800000 - speed)//100000)
+                        subport = int(fvp['subport'])
+                        reg_mask = (~(mask << ((subport - 1) * (speed//100000)))) & 0xFF
+                        reg_val = int(read_sysfs_file(admin_file_name), 16)
+                        reg_val = reg_val & reg_mask
+                        admin = {'up': 1, 'down': 0}[fvp['admin_status']]
+                        set_bits = mask if admin else 0
+                        result = reg_val | (set_bits << ((subport - 1) * (speed//100000)))
+                        write_sysfs_file(admin_file_name, hex(result))
+
+            if 'speed' in fvp:
+                if fvp['speed'] == '800000':
+                    if read_sysfs_file(brkt_file_name) != '0x00':
+                        write_sysfs_file(brkt_file_name, '0x0')
+                elif fvp['speed'] == '400000':
+                    if fvp['subport'] == '1' and read_sysfs_file(brkt_file_name) != '0x11':
+                        write_sysfs_file(brkt_file_name, '0x11')
 
     return 0
 

--- a/ixr7220h6-128/service/70-bmc-usb-network.rules
+++ b/ixr7220h6-128/service/70-bmc-usb-network.rules
@@ -1,0 +1,3 @@
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="usb0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="bmc_network_init.service"
+SUBSYSTEM=="net", ACTION=="change", KERNEL=="usb0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="bmc_network_init.service"
+SUBSYSTEM=="net", ACTION=="change", KERNEL=="bmc0", TAG+="systemd", ENV{SYSTEMD_WANTS}+="bmc_network_init.service"

--- a/ixr7220h6-128/service/bmc_network_init.service
+++ b/ixr7220h6-128/service/bmc_network_init.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nokia BMC Network Service
+Documentation=https://github.com/sonic-net/SONiC/wiki/
+After=systemd-modules-load.service local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/bmc_network_init.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/ixr7220h6-128/service/bmc_network_init.service
+++ b/ixr7220h6-128/service/bmc_network_init.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Nokia BMC Network Service
 Documentation=https://github.com/sonic-net/SONiC/wiki/
-After=systemd-modules-load.service local-fs.target
+After=systemd-modules-load.service local-fs.target sys-subsystem-net-devices-usb0.device
+BindsTo=sys-subsystem-net-devices-usb0.device
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/bmc_network_init.sh
-RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sys-subsystem-net-devices-usb0.device

--- a/ixr7220h6-128/sonic_platform/chassis.py
+++ b/ixr7220h6-128/sonic_platform/chassis.py
@@ -198,7 +198,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Model/part number of chassis
         """
-        return self._eeprom.part_number_str()
+        return self._eeprom.modelstr()
 
     def get_serial(self):
         """
@@ -285,8 +285,6 @@ class Chassis(ChassisBase):
             is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
             to pass a description of the reboot cause.
         """
-        return (self.REBOOT_CAUSE_NON_HARDWARE, None)
-    
         result = read_sysfs_file(SYSFPGA_DIR + "reset_cause")
 
         if (int(result, 16) & 0x10) >> 4 == 1:
@@ -300,7 +298,7 @@ class Chassis(ChassisBase):
 
         if (int(result, 16) & 0x08) >> 3 == 1:
             return (self.REBOOT_CAUSE_HARDWARE_OTHER, "Power Cycle")
-        
+
         return (self.REBOOT_CAUSE_NON_HARDWARE, None)
 
     def get_watchdog(self):
@@ -393,7 +391,7 @@ class Chassis(ChassisBase):
             return self.system_led_supported_color[1]
         if val == 0x5:
             return self.system_led_supported_color[0]
-        if val == 0x6:
+        if (val & 0x1) == 0x0:
             return self.system_led_supported_color[3]
         if val == 0x7:
             return self.system_led_supported_color[4]

--- a/ixr7220h6-128/sonic_platform/thermal_actions.py
+++ b/ixr7220h6-128/sonic_platform/thermal_actions.py
@@ -24,7 +24,7 @@ class SetFanSpeedAction(ThermalPolicyActionBase):
         """
         Constructor of SetFanSpeedAction
         """
-        self.default_speed = 47
+        self.default_speed = 46
         self.threshold1_speed = 60
         self.threshold2_speed = 80
         self.hightemp_speed = 100


### PR DESCRIPTION
[H6-128]:

- add bmc network service
- add support for breakout mode on port led
- fix reset reason
- enable 100G port led
- add support for 10G port
- update fan_cpld driver on pwm r/w
- fix FP system led amber check
- change chassis get_model() output to model name instead of PN